### PR TITLE
Add include and exclude options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,12 @@ docs/_build/
 *.sublime-project
 *.sublime-workspace
 
+# Ignore pycharm
+.idea
+
 # Ignore virtualenvs (who places it near)
 .venv/
+venv
 
 # Various shit from the OS itself
 .DS_Store

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,37 @@ paths
   Would only render the endpoints at ``/persons`` and ``/evidence``,
   ignoring all others.
 
+include
+  A line separated list of regular expressions to filter the included openapi
+  spec by. For example:
+
+  .. code:: restructuredtext
+
+     .. openapi:: specs/openapi.yml
+        :include:
+           /evid.*
+        :encoding: utf-8
+
+  Would render the endpoints at ``/evidence`` and ``/evidence/{pk}``
+
+exclude
+  A line separated list of regular expressions to filter the included openapi
+  spec by (excluding matches). For example:
+
+  .. code:: restructuredtext
+
+     .. openapi:: specs/openapi.yml
+        :exclude:
+           /evidence/{pk}
+        :encoding: utf-8
+
+  Would render ``/persons`` and ``/evidence`` endpoints, but not
+  ``/evidence/{pk}`` endpoints
+
+`exclude`, `include` and `paths` can also be used together (`exclude` taking
+precedence over `include` and `paths`)
+
+
 
 .. _Sphinx: https://sphinx.pocoo.org
 .. _OpenAPI: https://openapis.org/specification

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -154,6 +154,78 @@ class TestOpenApi2HttpDomain(object):
                   ok
         ''').lstrip()
 
+    def test_include_option(self):
+        spec = collections.defaultdict(collections.OrderedDict)
+        spec['paths']['/resource_a'] = {
+            'get': {
+                'description': 'resource a',
+                'responses': {
+                    '200': {'description': 'ok'},
+                }
+            }
+        }
+        spec['paths']['/resource_b'] = {
+            'post': {
+                'description': 'resource b',
+                'responses': {
+                    '404': {'description': 'error'},
+                }
+            }
+        }
+
+        text = '\n'.join(openapi.openapi2httpdomain(spec, include=[
+            '/resource',
+        ]))
+        assert text == textwrap.dedent('''
+            .. http:get:: /resource_a
+               :synopsis: null
+
+               resource a
+
+               :status 200:
+                  ok
+
+            .. http:post:: /resource_b
+               :synopsis: null
+
+               resource b
+
+               :status 404:
+                  error
+        ''').lstrip()
+
+    def test_exclude_option(self):
+        spec = collections.defaultdict(collections.OrderedDict)
+        spec['paths']['/resource_a'] = {
+            'get': {
+                'description': 'resource a',
+                'responses': {
+                    '200': {'description': 'ok'},
+                }
+            }
+        }
+        spec['paths']['/resource_b'] = {
+            'post': {
+                'description': 'resource b',
+                'responses': {
+                    '404': {'description': 'error'},
+                }
+            }
+        }
+
+        text = '\n'.join(openapi.openapi2httpdomain(spec, exclude=[
+            '/.*_a',
+        ]))
+        assert text == textwrap.dedent('''
+            .. http:post:: /resource_b
+               :synopsis: null
+
+               resource b
+
+               :status 404:
+                  error
+        ''').lstrip()
+
     def test_root_parameters(self):
         spec = {'paths': {}}
         spec['paths']['/resources/{name}'] = collections.OrderedDict()


### PR DESCRIPTION
For more control over openapi directive than the rather restrictive `paths`option, this PR adds `include` and `exclude` options that allow specifying paths to include / exclude using regular expressions.

```rst
.. openapi:: api.yaml
   :include:  /person.*
```

to render `/person`, `/person/{pk}`, `/person/{pk}/changepw` ... This allows splitting a big api specs file into small logical parts within the docs.

It also adds a local cache for deserialized specs to speedup openapi directive reuse.
