### PR TITLE
Run py2, py3 and docs tox envs by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37},docs
+envlist = py2, py3, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
tox without arguments is usually used on dev machines just to quickly
ensure nothing is broken. Dev machines rarely have all python versions
installed in the same time, so it would be better to use default py2 and
py3 versions instead of trying to run tests on specific versions.