### PR TITLE
Remove tox -e style env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,6 @@ commands =
     {envpython} -m flake8 sphinxcontrib/ tests/
     {envpython} -m pytest tests/ --strict  {posargs}
 
-[testenv:style]
-deps =
-    flake8
-commands =
-    {envpython} -m flake8 {posargs:sphinxcontrib/ tests/}
-
 [testenv:docs]
 deps = sphinx_rtd_theme
 commands =


### PR DESCRIPTION
There's no need to have a separate 'style' tox env to run flake8 linter
because we run it for every py{X} env before running tests with pytest.
That said, it's useless because if you run tests flake8 will be the
first check and will fail fast if some errors are found.