### PR TITLE
Migrate Travis CI to VM based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: xenial
 language: python
 
 matrix:
@@ -13,8 +13,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial  # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
-      sudo: true
     - env: TOXENV=docs
 
 install:


### PR DESCRIPTION
Travis CI has stopped supporting container based infrastructure and now
runs pretty much everything in VM based infrastructure [1]. That said,
in order to avoid confusion let's remove obsolete "sudo" key from Travis
CI as well as use xenial image to run tests as the more realistic to the
modern world choice.

[1] https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration