### PR TITLE
Run smoke tests agains OpenAPI specifications

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "OpenAPI-Specification"]
+	path = tests/OpenAPI-Specification
+	url = https://github.com/OAI/OpenAPI-Specification.git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals
+
+import textwrap
+
+import pytest
+
+from sphinx.application import Sphinx
+
+
+@pytest.fixture(scope='function')
+def run_sphinx(tmpdir):
+    src = tmpdir.ensure('src', dir=True)
+    out = tmpdir.ensure('out', dir=True)
+
+    def run(spec, options=None):
+        src.join('conf.py').write_text(
+            textwrap.dedent('''
+                import os
+
+                project = 'sphinxcontrib-openapi-test'
+                copyright = '2017, Ihor Kalnytskyi'
+
+                extensions = ['sphinxcontrib.openapi']
+                source_suffix = '.rst'
+                master_doc = 'index'
+            '''),
+            encoding='utf-8')
+
+        src.join('index.rst').write_text(
+            '.. openapi:: %s' % spec,
+            encoding='utf-8')
+
+        Sphinx(
+            srcdir=src.strpath,
+            confdir=src.strpath,
+            outdir=out.strpath,
+            doctreedir=out.join('.doctrees').strpath,
+            buildername='html'
+        ).build()
+
+    yield run

--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -1,0 +1,47 @@
+"""Smoke test examples from OAI/OpenAPI-Specification repo."""
+
+from __future__ import unicode_literals
+
+import os
+import glob
+import itertools
+
+import py
+import pytest
+
+
+@pytest.mark.parametrize('spec', itertools.chain(
+    glob.glob(
+        os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            'OpenAPI-Specification',
+            'examples',
+            'v2.0',
+            'json',
+            '*.json')),
+
+    glob.glob(
+        os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            'OpenAPI-Specification',
+            'examples',
+            'v2.0',
+            'yaml',
+            '*.yaml')),
+))
+def test_openapi2_success(tmpdir, run_sphinx, spec):
+    py.path.local(spec).copy(tmpdir.join('src', 'test-spec.yml'))
+    run_sphinx('test-spec.yml')
+
+
+@pytest.mark.parametrize('spec', glob.glob(
+    os.path.join(
+        os.path.abspath(os.path.dirname(__file__)),
+        'OpenAPI-Specification',
+        'examples',
+        'v3.0',
+        '*.yaml')
+))
+def test_openapi3_success(tmpdir, run_sphinx, spec):
+    py.path.local(spec).copy(tmpdir.join('src', 'test-spec.yml'))
+    run_sphinx('test-spec.yml')


### PR DESCRIPTION
We need to ensure that 'sphinxcontrib.openapi' does not fall at least on
a variety of spec examples from the official OpenAPI repo. Thus, let's
run tests against them.