### PR TITLE
Add ':examples:' directive option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ release.
 0.3.3 (unreleased)
 ==================
 
+- Add OpenAPI 3.x support.
 - Drop Python 3.3 support because it reached its end-of-life.
 
 0.3.2 (2017-10-05)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,10 @@ paths
   Would only render the endpoints at ``/persons`` and ``/evidence``,
   ignoring all others.
 
+examples
+  If passed, both request and response examples will be rendered. Please
+  note, if examples are not provided in a spec, they will be generated
+  by internal logic based on a corresponding schema.
 
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _OpenAPI: https://github.com/OAI/OpenAPI-Specification

--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -46,6 +46,7 @@ class OpenApi(Directive):
     option_spec = {
         'encoding': directives.encoding,    # useful for non-ascii cases :)
         'paths': lambda s: s.split(),       # endpoints to be rendered
+        'examples': directives.flag,        # render examples when passed
     }
 
     def run(self):

--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -69,6 +69,10 @@ def _httpresource(endpoint, method, properties):
 
 
 def openapihttpdomain(spec, **options):
+    if 'examples' in options:
+        raise ValueError(
+            'Rendering examples is not supported for OpenAPI v2.x specs.')
+
     generators = []
 
     # OpenAPI spec may contain JSON references, common properties, etc.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
 from __future__ import unicode_literals
 
 import textwrap
-
 import pytest
 
 from sphinx.application import Sphinx
+
+
+def _format_option_raw(key, val):
+    if isinstance(val, bool) and val:
+        return ':%s:' % key
+    return ':%s: %s' % (key, val)
 
 
 @pytest.fixture(scope='function')
@@ -12,7 +17,11 @@ def run_sphinx(tmpdir):
     src = tmpdir.ensure('src', dir=True)
     out = tmpdir.ensure('out', dir=True)
 
-    def run(spec, options=None):
+    def run(spec, options={}):
+        options_raw = '\n'.join([
+            '   %s' % _format_option_raw(key, val)
+            for key, val in options.items()])
+
         src.join('conf.py').write_text(
             textwrap.dedent('''
                 import os
@@ -27,7 +36,7 @@ def run_sphinx(tmpdir):
             encoding='utf-8')
 
         src.join('index.rst').write_text(
-            '.. openapi:: %s' % spec,
+            '.. openapi:: %s\n%s' % (spec, options_raw),
             encoding='utf-8')
 
         Sphinx(

--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -34,6 +34,7 @@ def test_openapi2_success(tmpdir, run_sphinx, spec):
     run_sphinx('test-spec.yml')
 
 
+@pytest.mark.parametrize('render_examples', [False, True])
 @pytest.mark.parametrize('spec', glob.glob(
     os.path.join(
         os.path.abspath(os.path.dirname(__file__)),
@@ -42,6 +43,6 @@ def test_openapi2_success(tmpdir, run_sphinx, spec):
         'v3.0',
         '*.yaml')
 ))
-def test_openapi3_success(tmpdir, run_sphinx, spec):
+def test_openapi3_success(tmpdir, run_sphinx, spec, render_examples):
     py.path.local(spec).copy(tmpdir.join('src', 'test-spec.yml'))
-    run_sphinx('test-spec.yml')
+    run_sphinx('test-spec.yml', options={'examples': render_examples})


### PR DESCRIPTION
Thanks to awesome contributions, sphinxcontrib.openapi now supports
examples generation based on provided schema. However, the code turns
out to be buggy and is not well tested. That's why we don't want to
enable it by default, so we need to come up with an option that can
enables this path.