### PR TITLE
Add ':group:' directive option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,10 @@ examples
   note, if examples are not provided in a spec, they will be generated
   by internal logic based on a corresponding schema.
 
+``group``
+  If passed, paths will be grouped by tags. If a path has no tag assigned, it
+  will be grouped in a ``default`` group.
+
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _OpenAPI: https://github.com/OAI/OpenAPI-Specification
 .. _sphinxcontrib-httpdomain: https://sphinxcontrib-httpdomain.readthedocs.io/

--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -47,6 +47,7 @@ class OpenApi(Directive):
         'encoding': directives.encoding,    # useful for non-ascii cases :)
         'paths': lambda s: s.split(),       # endpoints to be rendered
         'examples': directives.flag,        # render examples when passed
+        'group': directives.flag,           # group paths by tag when passed
     }
 
     def run(self):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -342,6 +342,112 @@ class TestOpenApi3HttpDomain(object):
                   Last known resource ETag.
         ''').lstrip()
 
+    def test_groups(self):
+        text = '\n'.join(openapi30.openapihttpdomain({
+            'openapi': '3.0.0',
+            'paths': {
+                '/': {
+                    'get': {
+                        'summary': 'Index',
+                        'description': '~ some useful description ~',
+                        'responses': {
+                            '200': {
+                                'description': 'Index',
+                                'content': {
+                                    'application/json': {
+                                        'pets': 'https://example.com/api/pets',
+                                        'tags': 'https://example.com/api/tags',
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+                '/pets': {
+                    'get': {
+                        'summary': 'List Pets',
+                        'description': '~ some useful description ~',
+                        'responses': {
+                            '200': {
+                                'description': 'Pets',
+                                'content': {
+                                    'application/json': [
+                                        {
+                                            'example': '{"foo": "bar"}'
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        'tags': [
+                            'pets',
+                        ],
+                    },
+                },
+                '/tags': {
+                    'get': {
+                        'summary': 'List Tags',
+                        'description': '~ some useful description ~',
+                        'responses': {
+                            '200': {
+                                'description': 'Tags',
+                                'content': {
+                                    'application/json': [
+                                        {
+                                            'example': '{"foo": "bar"}'
+                                        },
+                                    ],
+                                }
+                            },
+                        },
+                        'tags': [
+                            'tags',
+                        ],
+                    },
+                },
+            },
+        }, group=True))
+        assert text == textwrap.dedent('''
+            default
+            =======
+
+            .. http:get:: /
+               :synopsis: Index
+
+               **Index**
+
+               ~ some useful description ~
+
+               :status 200:
+                  Index
+
+            pets
+            ====
+
+            .. http:get:: /pets
+               :synopsis: List Pets
+
+               **List Pets**
+
+               ~ some useful description ~
+
+               :status 200:
+                  Pets
+
+            tags
+            ====
+
+            .. http:get:: /tags
+               :synopsis: List Tags
+
+               **List Tags**
+
+               ~ some useful description ~
+
+               :status 200:
+                  Tags
+        ''').lstrip()
+
     def test_example_generation(self):
         text = '\n'.join(openapi30.openapihttpdomain({
             'openapi': '3.0.0',

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -345,8 +345,8 @@ class TestOpenApi3HttpDomain(object):
     def test_groups(self):
         text = '\n'.join(openapi30.openapihttpdomain({
             'openapi': '3.0.0',
-            'paths': {
-                '/': {
+            'paths': collections.OrderedDict([
+                ('/', {
                     'get': {
                         'summary': 'Index',
                         'description': '~ some useful description ~',
@@ -362,8 +362,8 @@ class TestOpenApi3HttpDomain(object):
                             },
                         },
                     },
-                },
-                '/pets': {
+                }),
+                ('/pets', {
                     'get': {
                         'summary': 'List Pets',
                         'description': '~ some useful description ~',
@@ -383,8 +383,35 @@ class TestOpenApi3HttpDomain(object):
                             'pets',
                         ],
                     },
-                },
-                '/tags': {
+                }),
+                ('/pets/{name}', {
+                    'get': {
+                        'summary': 'Show Pet',
+                        'description': '~ some useful description ~',
+                        'parameters': [
+                            {
+                                'name': 'name',
+                                'in': 'path',
+                                'schema': {'type': 'string'},
+                                'description': 'Name of pet.',
+                            },
+                        ],
+                        'responses': {
+                            '200': {
+                                'description': 'A Pet',
+                                'content': {
+                                    'application/json': {
+                                        'example': '{"foo": "bar"}'
+                                    }
+                                }
+                            },
+                        },
+                        'tags': [
+                            'pets',
+                        ],
+                    },
+                }),
+                ('/tags', {
                     'get': {
                         'summary': 'List Tags',
                         'description': '~ some useful description ~',
@@ -402,10 +429,11 @@ class TestOpenApi3HttpDomain(object):
                         },
                         'tags': [
                             'tags',
+                            'pets',
                         ],
                     },
-                },
-            },
+                }),
+            ]),
         }, group=True))
         assert text == textwrap.dedent('''
             default
@@ -433,6 +461,18 @@ class TestOpenApi3HttpDomain(object):
 
                :status 200:
                   Pets
+
+            .. http:get:: /pets/{name}
+               :synopsis: Show Pet
+
+               **Show Pet**
+
+               ~ some useful description ~
+
+               :param string name:
+                  Name of pet.
+               :status 200:
+                  A Pet
 
             tags
             ====

--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -34,6 +34,7 @@ def test_openapi2_success(tmpdir, run_sphinx, spec):
     run_sphinx('test-spec.yml')
 
 
+@pytest.mark.parametrize('group_paths', [False, True])
 @pytest.mark.parametrize('render_examples', [False, True])
 @pytest.mark.parametrize('spec', glob.glob(
     os.path.join(
@@ -43,6 +44,10 @@ def test_openapi2_success(tmpdir, run_sphinx, spec):
         'v3.0',
         '*.yaml')
 ))
-def test_openapi3_success(tmpdir, run_sphinx, spec, render_examples):
+def test_openapi3_success(tmpdir, run_sphinx, spec, render_examples,
+                          group_paths):
     py.path.local(spec).copy(tmpdir.join('src', 'test-spec.yml'))
-    run_sphinx('test-spec.yml', options={'examples': render_examples})
+    run_sphinx('test-spec.yml', options={
+        'examples': render_examples,
+        'group': group_paths,
+    })


### PR DESCRIPTION
Provide a way to group common paths using tags. This is similar to what
'editor.swagger.io' does.

Signed-off-by: Stephen Finucane <stephen@that.guru>