### PR TITLE
Adding support for callbacks and other improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     namespace_packages=['sphinxcontrib'],
+    entry_points = {'console_scripts': 'oas2rst = sphinxcontrib.openapi.cmdline:main'}
 )

--- a/sphinxcontrib/openapi/cmdline.py
+++ b/sphinxcontrib/openapi/cmdline.py
@@ -21,6 +21,7 @@ _YamlOrderedLoader.add_constructor(
     lambda loader, node: collections.OrderedDict(loader.construct_pairs(node))
 )
 
+
 def main():
     parser = argparse.ArgumentParser(
         prog='oas2rst',
@@ -70,6 +71,7 @@ def main():
     for line in openapihttpdomain(spec, examples=True, **openapi_options):
         options.output.write(line+'\n')
         logging.debug(line)
+
 
 if __name__ == '__main__':
     main()

--- a/sphinxcontrib/openapi/cmdline.py
+++ b/sphinxcontrib/openapi/cmdline.py
@@ -15,19 +15,21 @@ from sphinxcontrib.openapi import openapi30
 class _YamlOrderedLoader(yaml.SafeLoader):
     pass
 
+
 _YamlOrderedLoader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
     lambda loader, node: collections.OrderedDict(loader.construct_pairs(node))
 )
+
 
 class OpenApi(object):
 
     def __init__(self):
         self.options = {}
 
-    def run(self,options):
+    def run(self, options):
 
-        encoding = "ascii" #
+        encoding = "ascii"
         with io.open(options.input, 'rt', encoding=encoding) as stream:
             spec = yaml.load(stream, _YamlOrderedLoader)
 
@@ -48,28 +50,43 @@ class OpenApi(object):
         else:
             raise ValueError('Unsupported OpenAPI version (%s)' % spec_version)
 
-        for line in openapihttpdomain(spec, examples=True,**self.options):
+        for line in openapihttpdomain(spec, examples=True, **self.options):
             options.output.write(line+'\n')
             logging.debug(line)
 
+
 def main():
-    
-    parser = argparse.ArgumentParser(prog='oas2rst',description='Export OpenAPI Specification files to reStructuredText files')
-    parser.add_argument("-l", "--level",action='store',default=logging.INFO,dest='level',help="Logging level")
-    parser.add_argument("-i", "--input",dest='input',required=True,help="Input file")
-    parser.add_argument("-o", "--output",type=argparse.FileType('w'),required=True,dest='output',help="Output file")
+    parser = argparse.ArgumentParser(
+        prog='oas2rst',
+        description='Export OpenAPI Specification files to reStructuredText \
+            files')
+    parser.add_argument(
+        "-l", "--level",
+        action='store',
+        default=logging.INFO,
+        dest='level',
+        help="Logging level")
+    parser.add_argument(
+        "-i", "--input",
+        dest='input',
+        required=True,
+        help="Input file")
+    parser.add_argument(
+        "-o", "--output",
+        type=argparse.FileType('w'),
+        required=True,
+        dest='output',
+        help="Output file")
 
     options = parser.parse_args()
-    logging.getLogger().setLevel( options.level) #getattr(logging,options.level) )
+    logging.getLogger().setLevel(options.level)
 
     oa = OpenApi()
     oa.run(options)
 
+
 def mime_sample():
-    import email
     from email.mime.multipart import MIMEMultipart
-    from email.mime.text import MIMEText
-    from email.mime.application import MIMEApplication
     from email.mime.nonmultipart import MIMENonMultipart
 
     related = MIMEMultipart('mixed')
@@ -83,19 +100,18 @@ def mime_sample():
     related.attach(document)
 
     document = MIMENonMultipart('image', 'png')
-    document.set_payload("%PNG...") #.encode("latin-1"))
+    document.set_payload("%PNG...")
     del document['MIME-Version']
     related.attach(document)
 
     document = MIMENonMultipart('image', 'jpeg')
-    document.set_payload("ÿØÿá...") #.encode("ascii"))
+    document.set_payload("ÿØÿá...")
     del document['MIME-Version']
     related.attach(document)
 
     data = related.as_string()
     print(data)
-    
-import sys
-if __name__=='__main__':
-    main()
 
+
+if __name__ == '__main__':
+    main()

--- a/sphinxcontrib/openapi/cmdline.py
+++ b/sphinxcontrib/openapi/cmdline.py
@@ -50,6 +50,13 @@ def main():
         required=True,
         dest='output',
         help="Output file")
+    parser.add_argument(
+        "-I", "--indent",
+        action='store',
+        type=int,
+        default=3,
+        dest='indent',
+        help="Indentation level")
 
     options = parser.parse_args()
     logging.getLogger().setLevel(options.level)
@@ -61,6 +68,7 @@ def main():
         openapi_options['examples'] = True
     if options.group:
         openapi_options['group'] = True
+    openapi_options['indent'] = options.indent
     openapihttpdomain, spec = \
         directive.get_openapihttpdomain(
             openapi_options,

--- a/sphinxcontrib/openapi/cmdline.py
+++ b/sphinxcontrib/openapi/cmdline.py
@@ -2,24 +2,9 @@
 from __future__ import unicode_literals
 
 import argparse
-import collections
-import io
 import logging
 
-import yaml
-
-from sphinxcontrib.openapi import openapi20
-from sphinxcontrib.openapi import openapi30
-
-
-class _YamlOrderedLoader(yaml.SafeLoader):
-    pass
-
-
-_YamlOrderedLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    lambda loader, node: collections.OrderedDict(loader.construct_pairs(node))
-)
+from sphinxcontrib.openapi import directive
 
 
 def main():
@@ -33,6 +18,27 @@ def main():
         default=logging.INFO,
         dest='level',
         help="Logging level")
+    parser.add_argument(
+        "-e", "--encoding",
+        action='store',
+        default="ascii",
+        dest='encoding',
+        help="Source file encoding")
+    parser.add_argument(
+        "-p", "--paths",
+        action='append',
+        dest='paths',
+        help="Endpoints to be rendered")
+    parser.add_argument(
+        "-x", "--examples",
+        action='store_true',
+        dest='examples',
+        help="Include examples")
+    parser.add_argument(
+        "-g", "--group",
+        action='store_true',
+        dest='group',
+        help="Group paths by tag")
     parser.add_argument(
         "-i", "--input",
         dest='input',
@@ -48,27 +54,20 @@ def main():
     options = parser.parse_args()
     logging.getLogger().setLevel(options.level)
 
-    with io.open(options.input, 'rt', encoding="ascii") as stream:
-        spec = yaml.load(stream, _YamlOrderedLoader)
+    openapi_options = {}
+    if options.paths:
+        openapi_options['paths'] = options.paths
+    if options.examples:
+        openapi_options['examples'] = True
+    if options.group:
+        openapi_options['group'] = True
+    openapihttpdomain, spec = \
+        directive.get_openapihttpdomain(
+            openapi_options,
+            options.input,
+            options.encoding)
 
-    # URI parameter is crucial for resolving relative references. So
-    # we need to set this option properly as it's used later down the
-    # stack.
-    openapi_options = {'uri': 'file://%s' % options.input}
-
-    # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
-    # determine which version we are parsing here.
-    spec_version = spec.get('openapi', spec.get('swagger', '2.0'))
-    if spec_version.startswith('2.'):
-        logging.info("OpenAPI 2.x Specification")
-        openapihttpdomain = openapi20.openapihttpdomain
-    elif spec_version.startswith('3.'):
-        logging.info("OpenAPI 3.x Specification")
-        openapihttpdomain = openapi30.openapihttpdomain
-    else:
-        raise ValueError('Unsupported OpenAPI version (%s)' % spec_version)
-
-    for line in openapihttpdomain(spec, examples=True, **openapi_options):
+    for line in openapihttpdomain(spec, **openapi_options):
         options.output.write(line+'\n')
         logging.debug(line)
 

--- a/sphinxcontrib/openapi/cmdline.py
+++ b/sphinxcontrib/openapi/cmdline.py
@@ -1,0 +1,101 @@
+
+from __future__ import unicode_literals
+
+import argparse
+import collections
+import io
+import logging
+
+import yaml
+
+from sphinxcontrib.openapi import openapi20
+from sphinxcontrib.openapi import openapi30
+
+
+class _YamlOrderedLoader(yaml.SafeLoader):
+    pass
+
+_YamlOrderedLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    lambda loader, node: collections.OrderedDict(loader.construct_pairs(node))
+)
+
+class OpenApi(object):
+
+    def __init__(self):
+        self.options = {}
+
+    def run(self,options):
+
+        encoding = "ascii" #
+        with io.open(options.input, 'rt', encoding=encoding) as stream:
+            spec = yaml.load(stream, _YamlOrderedLoader)
+
+        # URI parameter is crucial for resolving relative references. So
+        # we need to set this option properly as it's used later down the
+        # stack.
+        self.options.setdefault('uri', 'file://%s' % options.input)
+
+        # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
+        # determine which version we are parsing here.
+        spec_version = spec.get('openapi', spec.get('swagger', '2.0'))
+        if spec_version.startswith('2.'):
+            logging.info("OpenAPI 2.x Specification")
+            openapihttpdomain = openapi20.openapihttpdomain
+        elif spec_version.startswith('3.'):
+            logging.info("OpenAPI 3.x Specification")
+            openapihttpdomain = openapi30.openapihttpdomain
+        else:
+            raise ValueError('Unsupported OpenAPI version (%s)' % spec_version)
+
+        for line in openapihttpdomain(spec, examples=True,**self.options):
+            options.output.write(line+'\n')
+            logging.debug(line)
+
+def main():
+    
+    parser = argparse.ArgumentParser(prog='oas2rst',description='Export OpenAPI Specification files to reStructuredText files')
+    parser.add_argument("-l", "--level",action='store',default=logging.INFO,dest='level',help="Logging level")
+    parser.add_argument("-i", "--input",dest='input',required=True,help="Input file")
+    parser.add_argument("-o", "--output",type=argparse.FileType('w'),required=True,dest='output',help="Output file")
+
+    options = parser.parse_args()
+    logging.getLogger().setLevel( options.level) #getattr(logging,options.level) )
+
+    oa = OpenApi()
+    oa.run(options)
+
+def mime_sample():
+    import email
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+    from email.mime.application import MIMEApplication
+    from email.mime.nonmultipart import MIMENonMultipart
+
+    related = MIMEMultipart('mixed')
+
+    def noop_encoder(msg):
+        pass
+
+    document = MIMENonMultipart('application', 'pdf')
+    document.set_payload("%PDF-1.4...".encode("ascii"))
+    del document['MIME-Version']
+    related.attach(document)
+
+    document = MIMENonMultipart('image', 'png')
+    document.set_payload("%PNG...") #.encode("latin-1"))
+    del document['MIME-Version']
+    related.attach(document)
+
+    document = MIMENonMultipart('image', 'jpeg')
+    document.set_payload("ÿØÿá...") #.encode("ascii"))
+    del document['MIME-Version']
+    related.attach(document)
+
+    data = related.as_string()
+    print(data)
+    
+import sys
+if __name__=='__main__':
+    main()
+

--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -39,6 +39,27 @@ _YamlOrderedLoader.add_constructor(
 )
 
 
+def get_openapihttpdomain(options, abspath, encoding):
+    with io.open(abspath, 'rt', encoding=encoding) as stream:
+        spec = yaml.load(stream, _YamlOrderedLoader)
+
+    # URI parameter is crucial for resolving relative references. So
+    # we need to set this option properly as it's used later down the
+    # stack.
+    options.setdefault('uri', 'file://%s' % abspath)
+
+    # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
+    # determine which version we are parsing here.
+    spec_version = spec.get('openapi', spec.get('swagger', '2.0'))
+    if spec_version.startswith('2.'):
+        openapihttpdomain = openapi20.openapihttpdomain
+    elif spec_version.startswith('3.'):
+        openapihttpdomain = openapi30.openapihttpdomain
+    else:
+        raise ValueError('Unsupported OpenAPI version (%s)' % spec_version)
+    return openapihttpdomain, spec
+
+
 class OpenApi(Directive):
 
     required_arguments = 1                  # path to openapi spec
@@ -61,23 +82,10 @@ class OpenApi(Directive):
         # Read the spec using encoding passed to the directive or fallback to
         # the one specified in Sphinx's config.
         encoding = self.options.get('encoding', env.config.source_encoding)
-        with io.open(abspath, 'rt', encoding=encoding) as stream:
-            spec = yaml.load(stream, _YamlOrderedLoader)
 
-        # URI parameter is crucial for resolving relative references. So
-        # we need to set this option properly as it's used later down the
-        # stack.
-        self.options.setdefault('uri', 'file://%s' % abspath)
-
-        # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
-        # determine which version we are parsing here.
-        spec_version = spec.get('openapi', spec.get('swagger', '2.0'))
-        if spec_version.startswith('2.'):
-            openapihttpdomain = openapi20.openapihttpdomain
-        elif spec_version.startswith('3.'):
-            openapihttpdomain = openapi30.openapihttpdomain
-        else:
-            raise ValueError('Unsupported OpenAPI version (%s)' % spec_version)
+        # Open the specification file
+        openapihttpdomain, spec = \
+            get_openapihttpdomain(self.options, abspath, encoding)
 
         # reStructuredText DOM manipulation is pretty tricky task. It requires
         # passing dozen arguments which is not easy without well-documented

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -166,8 +166,9 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
             status_text = '-'
 
     # Provide request samples for GET requests
-    if method=='GET' and not media_type_objects:
-        media_type_objects[''] = {'examples':{'Example request':{'value':''}}}
+    if method == 'GET' and not media_type_objects:
+        media_type_objects[''] = \
+            {'examples': {'Example request': {'value': ''}}}
 
     for content_type, content in media_type_objects.items():
         examples = content.get('examples')
@@ -215,7 +216,8 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
                 yield '{extra_indent}{indent}Host: example.com' \
                     .format(**locals())
                 if content_type:
-                    yield '{extra_indent}{indent}Content-Type: {content_type}' \
+                    yield \
+                        '{extra_indent}{indent}Content-Type: {content_type}' \
                         .format(**locals())
 
             # Print http response example
@@ -268,12 +270,17 @@ def _httpresource(endpoint, method, properties, render_examples):
             name=param['name'])
         for line in param.get('description', '').splitlines():
             yield '{indent}{indent}{line}'.format(**locals())
-        if param.get('required',False):
+        if param.get('required', False):
             yield '{indent}{indent}(Required)'.format(**locals())
-            if (param['schema']['type'], param['schema'].get('format')) in _TYPE_MAPPING:
-                query_param_examples[param['name']] = _TYPE_MAPPING[(param['schema']['type'], param['schema'].get('format'))]
+            if (param['schema']['type'], param['schema'].get('format')) \
+                    in _TYPE_MAPPING:
+                query_param_examples[param['name']] = _TYPE_MAPPING[(
+                            param['schema']['type'],
+                            param['schema'].get('format')
+                            )]
             else:
-                query_param_examples[param['name']] = _TYPE_MAPPING[(param['schema']['type'], None)]
+                query_param_examples[param['name']] = \
+                    _TYPE_MAPPING[(param['schema']['type'], None)]
 
     # print response status codes
     for status, response in responses.items():
@@ -286,7 +293,7 @@ def _httpresource(endpoint, method, properties, render_examples):
         yield indent + ':reqheader {name}:'.format(**param)
         for line in param.get('description', '').splitlines():
             yield '{indent}{indent}{line}'.format(**locals())
-        if param.get('required',False):
+        if param.get('required', False):
             yield '{indent}{indent}(Required)'.format(**locals())
 
     # print response headers
@@ -297,11 +304,15 @@ def _httpresource(endpoint, method, properties, render_examples):
                 yield '{indent}{indent}{line}'.format(**locals())
 
     if render_examples:
-        endpoint_examples = endpoint + "?" + parse.urlencode(query_param_examples)
+        endpoint_examples = endpoint + "?" + \
+            parse.urlencode(query_param_examples)
         # print request example
         request_content = properties.get('requestBody', {}).get('content', {})
         for line in _example(
-                request_content, method, endpoint=endpoint_examples, nb_indent=1):
+                request_content,
+                method,
+                endpoint=endpoint_examples,
+                nb_indent=1):
             yield line
 
         # print response status codes
@@ -311,7 +322,7 @@ def _httpresource(endpoint, method, properties, render_examples):
                     response.get('content', {}), status=status, nb_indent=1):
                 yield line
 
-    for cb_name,cb_specs in properties.get('callbacks',{}).items():
+    for cb_name, cb_specs in properties.get('callbacks', {}).items():
         yield ''
         yield '.. admonition:: Callback: ' + cb_name
         yield ''
@@ -319,10 +330,10 @@ def _httpresource(endpoint, method, properties, render_examples):
         for cb_endpoint in cb_specs.keys():
             for cb_method, cb_properties in cb_specs[cb_endpoint].items():
                 for line in _httpresource(
-                    cb_endpoint,
-                    cb_method,
-                    cb_properties,
-                    render_examples=render_examples):
+                        cb_endpoint,
+                        cb_method,
+                        cb_properties,
+                        render_examples=render_examples):
                     yield indent+line
 
     yield ''

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -167,8 +167,8 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
 
     # Provide request samples for GET requests
     if method == 'GET' and not media_type_objects:
-        media_type_objects[''] = \
-            {'examples': {'Example request': {'value': ''}}}
+        media_type_objects[''] = {
+            'examples': {'Example request': {'value': ''}}}
 
     for content_type, content in media_type_objects.items():
         examples = content.get('examples')

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -216,8 +216,7 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
                 yield '{extra_indent}{indent}Host: example.com' \
                     .format(**locals())
                 if content_type:
-                    yield \
-                        '{extra_indent}{indent}Content-Type: {content_type}' \
+                    yield '{extra_indent}{indent}Content-Type: {content_type}'\
                         .format(**locals())
 
             # Print http response example
@@ -241,7 +240,7 @@ def _httpresource(endpoint, method, properties, render_examples):
     indent = '    '
 
     yield '.. http:{0}:: {1}'.format(method, endpoint)
-    yield indent+':synopsis: {0}'.format(properties.get('summary', 'null'))
+    yield indent + ':synopsis: {0}'.format(properties.get('summary', 'null'))
     yield ''
 
     if 'summary' in properties:

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -138,7 +138,7 @@ def _parse_schema(schema, method):
 
 
 def _example(media_type_objects, method=None, endpoint=None, status=None,
-             nb_indent=0):
+             nb_indent=0, indent_lvl=3):
     """
     Format examples in `Media Type Object` openapi v3 to HTTP request or
     HTTP response example.
@@ -152,7 +152,7 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
         endpoint: The HTTP route to use in example.
         status: The HTTP status to use in example.
     """
-    indent = '    '
+    indent = ' ' * indent_lvl
     extra_indent = indent * nb_indent
 
     if method is not None:
@@ -232,12 +232,12 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
             yield ''
 
 
-def _httpresource(endpoint, method, properties, render_examples):
+def _httpresource(endpoint, method, properties, render_examples, indent_lvl=3):
     # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#operation-object
     parameters = properties.get('parameters', [])
     responses = properties['responses']
     query_param_examples = {}
-    indent = '    '
+    indent = ' ' * indent_lvl
 
     yield '.. http:{0}:: {1}'.format(method, endpoint)
     yield indent + ':synopsis: {0}'.format(properties.get('summary', 'null'))
@@ -315,14 +315,16 @@ def _httpresource(endpoint, method, properties, render_examples):
                 request_content,
                 method,
                 endpoint=endpoint_examples,
-                nb_indent=1):
+                nb_indent=1,
+                indent_lvl=indent_lvl):
             yield line
 
         # print response status codes
         for status, response in responses.items():
             # print response example
             for line in _example(
-                    response.get('content', {}), status=status, nb_indent=1):
+                    response.get('content', {}), status=status, nb_indent=1,
+                    indent_lvl=indent_lvl):
                 yield line
 
     for cb_name, cb_specs in properties.get('callbacks', {}).items():
@@ -336,7 +338,8 @@ def _httpresource(endpoint, method, properties, render_examples):
                         cb_endpoint,
                         cb_method,
                         cb_properties,
-                        render_examples=render_examples):
+                        render_examples=render_examples,
+                        indent_lvl=indent_lvl):
                     if line:
                         yield indent+line
                     else:
@@ -381,7 +384,8 @@ def openapihttpdomain(spec, **options):
                     endpoint,
                     method,
                     properties,
-                    render_examples='examples' in options))
+                    render_examples='examples' in options,
+                    indent_lvl=options.get('indent', 3)))
 
         for key in sorted(groups.keys()):
             if key:
@@ -397,6 +401,7 @@ def openapihttpdomain(spec, **options):
                     endpoint,
                     method,
                     properties,
-                    render_examples='examples' in options))
+                    render_examples='examples' in options,
+                    indent_lvl=options.get('indent', 3)))
 
     return iter(itertools.chain(*generators))

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -277,9 +277,10 @@ def _httpresource(endpoint, method, properties, render_examples, indent_lvl=3):
                             param['schema']['type'],
                             param['schema'].get('format')
                             )]
-            else:
+            elif (param['schema']['type'], None) in _TYPE_MAPPING:
                 query_param_examples[param['name']] = \
                     _TYPE_MAPPING[(param['schema']['type'], None)]
+            # else: no sample available
 
     # print response status codes
     for status, response in responses.items():

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -304,8 +304,12 @@ def _httpresource(endpoint, method, properties, render_examples):
                 yield '{indent}{indent}{line}'.format(**locals())
 
     if render_examples:
-        endpoint_examples = endpoint + "?" + \
-            parse.urlencode(query_param_examples)
+        if query_param_examples:
+            endpoint_examples = endpoint + "?" + \
+                parse.urlencode(query_param_examples)
+        else:
+            endpoint_examples = endpoint
+
         # print request example
         request_content = properties.get('requestBody', {}).get('content', {})
         for line in _example(

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -338,7 +338,10 @@ def _httpresource(endpoint, method, properties, render_examples):
                         cb_method,
                         cb_properties,
                         render_examples=render_examples):
-                    yield indent+line
+                    if line:
+                        yield indent+line
+                    else:
+                        yield ''
 
     yield ''
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -819,7 +819,7 @@ class TestOpenApi3HttpDomain(object):
                             {
                                 'name': 'callback',
                                 'in': 'query',
-                                'description': 'the callback address, where the result will be sent when available',
+                                'description': 'the callback address',
                                 'required': False,
                                 'schema': {
                                     'type': 'string',
@@ -853,7 +853,7 @@ class TestOpenApi3HttpDomain(object):
                                         'operationId': 'sampleCB',
                                         'requestBody': {
                                             'required': True,
-                                            'description': 'Result of the insertion',
+                                            'description': 'Result',
                                             'content': {
                                                 'application/json': {
                                                     'schema': {
@@ -861,8 +861,12 @@ class TestOpenApi3HttpDomain(object):
                                                         'required': ['status'],
                                                         'properties': {
                                                             'status': {
-                                                                'type': 'string',
-                                                                'enum': ['OK', 'ERROR']
+                                                                'type':
+                                                                    'string',
+                                                                'enum': [
+                                                                    'OK',
+                                                                    'ERROR'
+                                                                ]
                                                             }
                                                         }
                                                     }
@@ -893,20 +897,20 @@ class TestOpenApi3HttpDomain(object):
                 :param string kind:
                     Kind of resource to list.
                 :query string callback:
-                    the callback address, where the result will be sent when available
+                    the callback address
                 :status 202:
                     Something
 
             .. admonition:: Callback: callback
-         
+
                 .. http:post:: ${request.query.callback}
                     :synopsis: Response callback
-                    
+
                     **Response callback**
-                
+
                     :status 200:
                         Success
-                
+
         ''').lstrip()
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -326,20 +326,20 @@ class TestOpenApi3HttpDomain(object):
         }))
         assert text == textwrap.dedent('''
             .. http:get:: /resources/{kind}
-                :synopsis: List Resources
+               :synopsis: List Resources
 
-                **List Resources**
+               **List Resources**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :param string kind:
-                    Kind of resource to list.
-                :query integer limit:
-                    Show up to `limit` entries.
-                :status 200:
-                    An array of resources.
-                :reqheader If-None-Match:
-                    Last known resource ETag.
+               :param string kind:
+                  Kind of resource to list.
+               :query integer limit:
+                  Show up to `limit` entries.
+               :status 200:
+                  An array of resources.
+               :reqheader If-None-Match:
+                  Last known resource ETag.
         ''').lstrip()
 
     def test_groups(self):
@@ -440,52 +440,52 @@ class TestOpenApi3HttpDomain(object):
             =======
 
             .. http:get:: /
-                :synopsis: Index
+               :synopsis: Index
 
-                **Index**
+               **Index**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :status 200:
-                    Index
+               :status 200:
+                  Index
 
             pets
             ====
 
             .. http:get:: /pets
-                :synopsis: List Pets
+               :synopsis: List Pets
 
-                **List Pets**
+               **List Pets**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :status 200:
-                    Pets
+               :status 200:
+                  Pets
 
             .. http:get:: /pets/{name}
-                :synopsis: Show Pet
+               :synopsis: Show Pet
 
-                **Show Pet**
+               **Show Pet**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :param string name:
-                    Name of pet.
-                :status 200:
-                    A Pet
+               :param string name:
+                  Name of pet.
+               :status 200:
+                  A Pet
 
             tags
             ====
 
             .. http:get:: /tags
-                :synopsis: List Tags
+               :synopsis: List Tags
 
-                **List Tags**
+               **List Tags**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :status 200:
-                    Tags
+               :status 200:
+                  Tags
         ''').lstrip()
 
     def test_example_generation(self):
@@ -647,157 +647,157 @@ class TestOpenApi3HttpDomain(object):
 
         assert text == textwrap.dedent('''
             .. http:get:: /resources/
-                :synopsis: List Resources
+               :synopsis: List Resources
 
-                **List Resources**
+               **List Resources**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :param string kind:
-                    Kind of resource to list.
-                :query integer limit:
-                    Show up to `limit` entries.
-                :status 200:
-                    An array of resources.
-                :reqheader If-None-Match:
-                    Last known resource ETag.
+               :param string kind:
+                  Kind of resource to list.
+               :query integer limit:
+                  Show up to `limit` entries.
+               :status 200:
+                  An array of resources.
+               :reqheader If-None-Match:
+                  Last known resource ETag.
 
-                **Example request:**
+               **Example request:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    GET /resources/ HTTP/1.1
-                    Host: example.com
+                  GET /resources/ HTTP/1.1
+                  Host: example.com
 
 
 
-                **Example response:**
+               **Example response:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    HTTP/1.1 200 OK
-                    Content-Type: application/json
+                  HTTP/1.1 200 OK
+                  Content-Type: application/json
 
-                    [
-                        {
-                            "kind": "string",
-                            "description": "string",
-                            "data": "c3RyaW5n"
-                        }
-                    ]
+                  [
+                      {
+                          "kind": "string",
+                          "description": "string",
+                          "data": "c3RyaW5n"
+                      }
+                  ]
 
 
             .. http:post:: /resources/
-                :synopsis: Create Resource
+               :synopsis: Create Resource
 
-                **Create Resource**
+               **Create Resource**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :status 200:
-                    The created resource.
+               :status 200:
+                  The created resource.
 
-                **Example request:**
+               **Example request:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    POST /resources/ HTTP/1.1
-                    Host: example.com
-                    Content-Type: application/json
+                  POST /resources/ HTTP/1.1
+                  Host: example.com
+                  Content-Type: application/json
 
-                    {
-                        "description": "string",
-                        "data": "c3RyaW5n"
-                    }
+                  {
+                      "description": "string",
+                      "data": "c3RyaW5n"
+                  }
 
 
-                **Example response:**
+               **Example response:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    HTTP/1.1 200 OK
-                    Content-Type: application/json
+                  HTTP/1.1 200 OK
+                  Content-Type: application/json
 
-                    {
-                        "kind": "string",
-                        "description": "string",
-                        "data": "c3RyaW5n"
-                    }
+                  {
+                      "kind": "string",
+                      "description": "string",
+                      "data": "c3RyaW5n"
+                  }
 
 
             .. http:get:: /resources/{kind}
-                :synopsis: Show Resource
+               :synopsis: Show Resource
 
-                **Show Resource**
+               **Show Resource**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :param string kind:
-                    Kind of resource to list.
-                :status 200:
-                    The created resource.
+               :param string kind:
+                  Kind of resource to list.
+               :status 200:
+                  The created resource.
 
-                **Example request:**
+               **Example request:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    GET /resources/{kind} HTTP/1.1
-                    Host: example.com
+                  GET /resources/{kind} HTTP/1.1
+                  Host: example.com
 
 
 
-                **Example response:**
+               **Example response:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    HTTP/1.1 200 OK
-                    Content-Type: application/json
+                  HTTP/1.1 200 OK
+                  Content-Type: application/json
 
-                    {
-                        "kind": "string",
-                        "description": "string",
-                        "data": "c3RyaW5n"
-                    }
+                  {
+                      "kind": "string",
+                      "description": "string",
+                      "data": "c3RyaW5n"
+                  }
 
 
             .. http:patch:: /resources/{kind}
-                :synopsis: Update Resource (partial)
+               :synopsis: Update Resource (partial)
 
-                **Update Resource (partial)**
+               **Update Resource (partial)**
 
-                ~ some useful description ~
+               ~ some useful description ~
 
-                :param string kind:
-                    Kind of resource to list.
-                :status 200:
-                    The created resource.
+               :param string kind:
+                  Kind of resource to list.
+               :status 200:
+                  The created resource.
 
-                **Example request:**
+               **Example request:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    PATCH /resources/{kind} HTTP/1.1
-                    Host: example.com
-                    Content-Type: application/json
+                  PATCH /resources/{kind} HTTP/1.1
+                  Host: example.com
+                  Content-Type: application/json
 
-                    {
-                        "description": "string",
-                        "data": "c3RyaW5n"
-                    }
+                  {
+                      "description": "string",
+                      "data": "c3RyaW5n"
+                  }
 
 
-                **Example response:**
+               **Example response:**
 
-                .. sourcecode:: http
+               .. sourcecode:: http
 
-                    HTTP/1.1 200 OK
-                    Content-Type: application/json
+                  HTTP/1.1 200 OK
+                  Content-Type: application/json
 
-                    {
-                        "kind": "string",
-                        "description": "string",
-                        "data": "c3RyaW5n"
-                    }
+                  {
+                      "kind": "string",
+                      "description": "string",
+                      "data": "c3RyaW5n"
+                  }
 
         ''').lstrip()
 
@@ -885,7 +885,7 @@ class TestOpenApi3HttpDomain(object):
                     },
                 },
             },
-        }))
+        }, indent=4))
         assert text == textwrap.dedent('''
             .. http:post:: /resources/{kind}
                 :synopsis: List Resources

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -326,20 +326,20 @@ class TestOpenApi3HttpDomain(object):
         }))
         assert text == textwrap.dedent('''
             .. http:get:: /resources/{kind}
-               :synopsis: List Resources
+                :synopsis: List Resources
 
-               **List Resources**
+                **List Resources**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :param string kind:
-                  Kind of resource to list.
-               :query integer limit:
-                  Show up to `limit` entries.
-               :status 200:
-                  An array of resources.
-               :reqheader If-None-Match:
-                  Last known resource ETag.
+                :param string kind:
+                    Kind of resource to list.
+                :query integer limit:
+                    Show up to `limit` entries.
+                :status 200:
+                    An array of resources.
+                :reqheader If-None-Match:
+                    Last known resource ETag.
         ''').lstrip()
 
     def test_groups(self):
@@ -440,52 +440,52 @@ class TestOpenApi3HttpDomain(object):
             =======
 
             .. http:get:: /
-               :synopsis: Index
+                :synopsis: Index
 
-               **Index**
+                **Index**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :status 200:
-                  Index
+                :status 200:
+                    Index
 
             pets
             ====
 
             .. http:get:: /pets
-               :synopsis: List Pets
+                :synopsis: List Pets
 
-               **List Pets**
+                **List Pets**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :status 200:
-                  Pets
+                :status 200:
+                    Pets
 
             .. http:get:: /pets/{name}
-               :synopsis: Show Pet
+                :synopsis: Show Pet
 
-               **Show Pet**
+                **Show Pet**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :param string name:
-                  Name of pet.
-               :status 200:
-                  A Pet
+                :param string name:
+                    Name of pet.
+                :status 200:
+                    A Pet
 
             tags
             ====
 
             .. http:get:: /tags
-               :synopsis: List Tags
+                :synopsis: List Tags
 
-               **List Tags**
+                **List Tags**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :status 200:
-                  Tags
+                :status 200:
+                    Tags
         ''').lstrip()
 
     def test_example_generation(self):
@@ -647,139 +647,157 @@ class TestOpenApi3HttpDomain(object):
 
         assert text == textwrap.dedent('''
             .. http:get:: /resources/
-               :synopsis: List Resources
+                :synopsis: List Resources
 
-               **List Resources**
+                **List Resources**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :param string kind:
-                  Kind of resource to list.
-               :query integer limit:
-                  Show up to `limit` entries.
-               :status 200:
-                  An array of resources.
+                :param string kind:
+                    Kind of resource to list.
+                :query integer limit:
+                    Show up to `limit` entries.
+                :status 200:
+                    An array of resources.
+                :reqheader If-None-Match:
+                    Last known resource ETag.
 
-                  **Example response:**
+                **Example request:**
 
-                  .. sourcecode:: http
+                .. sourcecode:: http
 
-                     HTTP/1.1 200 OK
-                     Content-Type: application/json
+                    GET /resources/ HTTP/1.1
+                    Host: example.com
 
-                     [
-                         {
-                             "kind": "string",
-                             "description": "string",
-                             "data": "c3RyaW5n"
-                         }
-                     ]
 
-               :reqheader If-None-Match:
-                  Last known resource ETag.
+
+                **Example response:**
+
+                .. sourcecode:: http
+
+                    HTTP/1.1 200 OK
+                    Content-Type: application/json
+
+                    [
+                        {
+                            "kind": "string",
+                            "description": "string",
+                            "data": "c3RyaW5n"
+                        }
+                    ]
+
 
             .. http:post:: /resources/
-               :synopsis: Create Resource
+                :synopsis: Create Resource
 
-               **Create Resource**
+                **Create Resource**
 
-               ~ some useful description ~
+                ~ some useful description ~
+
+                :status 200:
+                    The created resource.
+
+                **Example request:**
+
+                .. sourcecode:: http
+
+                    POST /resources/ HTTP/1.1
+                    Host: example.com
+                    Content-Type: application/json
+
+                    {
+                        "description": "string",
+                        "data": "c3RyaW5n"
+                    }
 
 
-               **Example request:**
+                **Example response:**
 
-               .. sourcecode:: http
+                .. sourcecode:: http
 
-                  POST /resources/ HTTP/1.1
-                  Host: example.com
-                  Content-Type: application/json
+                    HTTP/1.1 200 OK
+                    Content-Type: application/json
 
-                  {
-                      "description": "string",
-                      "data": "c3RyaW5n"
-                  }
-
-               :status 200:
-                  The created resource.
-
-                  **Example response:**
-
-                  .. sourcecode:: http
-
-                     HTTP/1.1 200 OK
-                     Content-Type: application/json
-
-                     {
-                         "kind": "string",
-                         "description": "string",
-                         "data": "c3RyaW5n"
-                     }
+                    {
+                        "kind": "string",
+                        "description": "string",
+                        "data": "c3RyaW5n"
+                    }
 
 
             .. http:get:: /resources/{kind}
-               :synopsis: Show Resource
+                :synopsis: Show Resource
 
-               **Show Resource**
+                **Show Resource**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :param string kind:
-                  Kind of resource to list.
-               :status 200:
-                  The created resource.
+                :param string kind:
+                    Kind of resource to list.
+                :status 200:
+                    The created resource.
 
-                  **Example response:**
+                **Example request:**
 
-                  .. sourcecode:: http
+                .. sourcecode:: http
 
-                     HTTP/1.1 200 OK
-                     Content-Type: application/json
+                    GET /resources/{kind} HTTP/1.1
+                    Host: example.com
 
-                     {
-                         "kind": "string",
-                         "description": "string",
-                         "data": "c3RyaW5n"
-                     }
+
+
+                **Example response:**
+
+                .. sourcecode:: http
+
+                    HTTP/1.1 200 OK
+                    Content-Type: application/json
+
+                    {
+                        "kind": "string",
+                        "description": "string",
+                        "data": "c3RyaW5n"
+                    }
 
 
             .. http:patch:: /resources/{kind}
-               :synopsis: Update Resource (partial)
+                :synopsis: Update Resource (partial)
 
-               **Update Resource (partial)**
+                **Update Resource (partial)**
 
-               ~ some useful description ~
+                ~ some useful description ~
 
-               :param string kind:
-                  Kind of resource to list.
+                :param string kind:
+                    Kind of resource to list.
+                :status 200:
+                    The created resource.
 
-               **Example request:**
+                **Example request:**
 
-               .. sourcecode:: http
+                .. sourcecode:: http
 
-                  PATCH /resources/{kind} HTTP/1.1
-                  Host: example.com
-                  Content-Type: application/json
+                    PATCH /resources/{kind} HTTP/1.1
+                    Host: example.com
+                    Content-Type: application/json
 
-                  {
-                      "description": "string",
-                      "data": "c3RyaW5n"
-                  }
+                    {
+                        "description": "string",
+                        "data": "c3RyaW5n"
+                    }
 
-               :status 200:
-                  The created resource.
 
-                  **Example response:**
+                **Example response:**
 
-                  .. sourcecode:: http
+                .. sourcecode:: http
 
-                     HTTP/1.1 200 OK
-                     Content-Type: application/json
+                    HTTP/1.1 200 OK
+                    Content-Type: application/json
 
-                     {
-                         "kind": "string",
-                         "description": "string",
-                         "data": "c3RyaW5n"
-                     }
+                    {
+                        "kind": "string",
+                        "description": "string",
+                        "data": "c3RyaW5n"
+                    }
 
         ''').lstrip()
 


### PR DESCRIPTION
A set of modifications including (by order of importance):
- generate documentation for callbacks
- indicate mandatory parameters in the description text of the parameter
- generate request example for GET requests
- in the examples, add in the endpoint URL the mandatory query parameters
- group examples all together after the operation description
- A command line utility to export an OAS3 specification file to rst
- change indentation from 3 spaces to 4 spaces
