### PR TITLE
Markdown support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,11 @@ The ``openapi`` directive supports the following options:
   If passed, paths will be grouped by tags. If a path has no tag assigned, it
   will be grouped in a ``default`` group.
 
+``format``
+  The format of text in the spec, either ``rst`` or ``markdown``. If
+  not supplied, ReStructured Text is assumed.
+
+
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _OpenAPI: https://github.com/OAI/OpenAPI-Specification
 .. _sphinxcontrib-httpdomain: https://sphinxcontrib-httpdomain.readthedocs.io/

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ setup(
         'PyYAML >= 3.12',
         'jsonschema >= 2.5.1',
     ],
+    extras_require={
+        'markdown': [
+            'm2r',
+        ],
+    },
     classifiers=[
         'Topic :: Documentation',
         'License :: OSI Approved :: BSD License',

--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -48,6 +48,7 @@ class OpenApi(Directive):
         'paths': lambda s: s.split(),       # endpoints to be rendered
         'examples': directives.flag,        # render examples when passed
         'group': directives.flag,           # group paths by tag when passed
+        'format': str,                      # "rst" (default) or "markdown"
     }
 
     def run(self):

--- a/sphinxcontrib/openapi/utils.py
+++ b/sphinxcontrib/openapi/utils.py
@@ -13,6 +13,10 @@ from __future__ import unicode_literals
 import collections
 
 import jsonschema
+try:
+    from m2r import convert as convert_markdown
+except ImportError:
+    convert_markdown = None
 
 
 def _resolve_refs(uri, spec):
@@ -61,3 +65,18 @@ def normalize_spec(spec, **options):
         for method in endpoint.values():
             method.setdefault('parameters', [])
             method['parameters'].extend(parameters)
+
+
+def get_text_converter(options):
+    """Decide on a text converter for prose."""
+    if 'format' in options:
+        if options['format'] == 'markdown':
+            if convert_markdown is None:
+                raise ValueError(
+                    "Markdown conversion isn't available, "
+                    "install the [markdown] extra."
+                )
+            return convert_markdown
+
+    # No conversion needed.
+    return lambda s: s


### PR DESCRIPTION
The OpenAPI standard says that prose in an OpenAPI spec should be in Markdown.  This adds support for converting Markdown in the spec file into ReStructured Text for inclusion in the Sphinx process.

I haven't written tests yet, but I will if you like the idea.