### PR TITLE
Request body specification is missing in rendered documents.

### DIFF
--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -46,6 +46,7 @@ class OpenApi(Directive):
     option_spec = {
         'encoding': directives.encoding,    # useful for non-ascii cases :)
         'paths': lambda s: s.split(),       # endpoints to be rendered
+        'request': directives.flag,         # print the request body structure
         'examples': directives.flag,        # render examples when passed
         'group': directives.flag,           # group paths by tag when passed
     }


### PR DESCRIPTION
This solves the issue - POST request specs missing in rendered docs #38:
https://github.com/sphinx-contrib/openapi/issues/38#issue-420510546
