### PR TITLE
Use newer setuptools version for py36

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,17 @@ commands =
     {envpython} -m flake8 sphinxcontrib/ tests/
     {envpython} -m pytest tests/ --strict  {posargs}
 
+
+[testenv:py36]
+commands_pre =
+    # Unfortunately, Travis CI uses a pretty outdated version of setuptools
+    # package in Python 3.6 environments. That version has a bug that prevents
+    # using namespace packages [1]. Fortunately, it has been fixed in newer
+    # versions, thus we simply must update a setuptools version.
+    #
+    # https://github.com/pypa/setuptools/pull/1402/
+    {envpython} -m pip install -U setuptools>=40.3.0
+
 [testenv:docs]
 deps = sphinx_rtd_theme
 commands =


### PR DESCRIPTION
Unfortunately, Travis CI uses a pretty outdated version of setuptools package in Python 3.6 environments. That version has [a bug that prevents using namespace packages](https://github.com/pypa/setuptools/pull/1402/). Fortunately, it has been fixed in newer versions, thus we simply must update setuptools version.