### PR TITLE
Use $PYPI_USERNAME from Travis CI envvar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 
 deploy:
    - provider: pypi
-     user: ikalnytskyi
+     user: $PYPI_USERNAME
      password: $PYPI_PASSWORD
      on:
         tags: true


### PR DESCRIPTION
There two reasons why I want to see this change:

 1. Because I want everything be consistent and since PyPI password is
    set via environment variable, why shouldn't username?

 2. I started using PyPI tokens, and for tokens the username must be
    `__token__`. Hence, there was a need to update a username. Since
    tokens are in beta, there's a chance I'd need to rollback
    credentials change and I'd prefer to do it via Travis CI rather than
    Git.