### PR TITLE
Support missing properties tag in json schema

### DIFF
--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -120,7 +120,7 @@ def _parse_schema(schema, method):
     if schema_type == 'object':
         if method and 'properties' in schema and \
                 all(v.get('readOnly', False)
-                          for v in schema['properties'].values()):
+                    for v in schema['properties'].values()):
             return _READONLY_PROPERTY
 
         results = []

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -118,7 +118,8 @@ def _parse_schema(schema, method):
         return [_parse_schema(schema['items'], method)]
 
     if schema_type == 'object':
-        if method and all(v.get('readOnly', False)
+        if method and 'properties' in schema and \
+                all(v.get('readOnly', False)
                           for v in schema['properties'].values()):
             return _READONLY_PROPERTY
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1126,6 +1126,64 @@ class TestResolveRefs(object):
             }
         }
 
+    def test_noproperties(self):
+        text = '\n'.join(openapi30.openapihttpdomain({
+            'openapi': '3.0.0',
+            'paths': {
+                '/resources': {
+                    'post': {
+                        'summary': 'Create Resources',
+                        'description': '~ some useful description ~',
+                        'requestBody': {
+                            'content': {
+                                'application/json':  {
+                                    'schema': {
+                                        '$ref': '#/components/schemas/Resource',  # noqa
+                                    }
+                                }
+                            }
+                        },
+                        'responses': {
+                            '200': {
+                                'description': 'Something',
+                            },
+                        },
+                    },
+                },
+            },
+            'components': {
+                'schemas': {
+                    'Resource': {
+                        'type': 'object',
+                        'additionalProperties': True,
+                    },
+                },
+            },
+
+        }, examples=True))
+        assert text == textwrap.dedent('''
+            .. http:post:: /resources
+               :synopsis: Create Resources
+
+               **Create Resources**
+
+               ~ some useful description ~
+
+
+               **Example request:**
+         
+               .. sourcecode:: http
+         
+                  POST /resources HTTP/1.1
+                  Host: example.com
+                  Content-Type: application/json
+         
+                  {}
+
+               :status 200:
+                  Something
+        ''').lstrip()
+
 
 def test_openapi2_examples(tmpdir, run_sphinx):
     spec = os.path.join(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1171,13 +1171,13 @@ class TestResolveRefs(object):
 
 
                **Example request:**
-         
+
                .. sourcecode:: http
-         
+
                   POST /resources HTTP/1.1
                   Host: example.com
                   Content-Type: application/json
-         
+
                   {}
 
                :status 200:


### PR DESCRIPTION
As per the OpenAPI specs (See https://swagger.io/docs/specification/data-models/dictionaries/ for instance), it is possible to define a json schema with  additionalProperties only (and no properties).
This PR fixes the error generated in this case.