### PR TITLE
Add support for 'OneOf' in requestBody schemas

### DIFF
--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -267,19 +267,31 @@ def _httpresource(endpoint, method, properties, convert, render_examples,
 
     # print request content
     if render_request:
+        yield ''
         request_content = properties.get('requestBody', {}).get('content', {})
         if request_content and 'application/json' in request_content:
             schema = request_content['application/json']['schema']
-            req_properties = json.dumps(schema['properties'], indent=2,
-                                        separators=(',', ':'))
-            yield '{indent}**Request body:**'.format(**locals())
-            yield ''
-            yield '{indent}.. sourcecode:: json'.format(**locals())
-            yield ''
-            for line in req_properties.splitlines():
-                # yield indent + line
-                yield '{indent}{indent}{line}'.format(**locals())
-                # yield ''
+            schs = []
+            if 'oneOf' in schema:
+                schs = schema['oneOf']
+            else:
+                schs = [schema]
+            if len(schs) > 1:
+                yield ('{indent}The request accepts '
+                       'the following bodies:'.format(**locals()))
+                yield ''
+            for sch in schs:
+                req_properties = json.dumps(sch['properties'], indent=2,
+                                            separators=(',', ':'))
+                yield '{indent}**Request body:**'.format(**locals())
+                yield ''
+                yield '{indent}.. sourcecode:: json'.format(**locals())
+                yield ''
+                for line in req_properties.splitlines():
+                    # yield indent + line
+                    yield '{indent}{indent}{line}'.format(**locals())
+                    # yield ''
+                yield ''
 
     # print request example
     if render_examples:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1074,6 +1074,90 @@ class TestOpenApi3HttpDomain(object):
 
         ''').lstrip()
 
+    def test_oneOf_requestBody(self):
+        text = '\n'.join(openapi30.openapihttpdomain({
+            'openapi': '3.0.0.',
+            'paths': {
+                '/testpath': {
+                    'post': {
+                        'summary': 'a test POST',
+                        'description': 'N/A',
+                        'parameters': [],
+                        'requestBody': {
+                            'content': {
+                                'application/json': {
+                                    'schema': {
+                                        'oneOf': [
+                                            {'description': 'request body 1',
+                                             'type': 'object',
+                                             'properties': {
+                                                'A': {
+                                                    'type': 'string'
+                                                },
+                                              }
+                                             },
+                                            {'description': 'request body 2',
+                                             'type': 'object',
+                                             'properties': {
+                                                'B': {
+                                                    'type': 'string'
+                                                },
+                                              }
+                                             }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        'responses': {
+                            '202': {
+                                'description': 'created',
+                                'content': {
+                                    'application/json': {
+                                        'example': '{"foo": "bar"}'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }, request=True))
+        assert text == textwrap.dedent('''
+            .. http:post:: /testpath
+               :synopsis: a test POST
+
+               **a test POST**
+
+               N/A
+
+
+               The request accepts the following bodies:
+
+               **Request body:**
+
+               .. sourcecode:: json
+
+                  {
+                    "A":{
+                      "type":"string"
+                    }
+                  }
+
+               **Request body:**
+
+               .. sourcecode:: json
+
+                  {
+                    "B":{
+                      "type":"string"
+                    }
+                  }
+
+               :status 202:
+                  created
+        ''').lstrip()
+
 
 class TestResolveRefs(object):
 


### PR DESCRIPTION
Compliant with OpenAPI v3.0

Closes #53