### PR TITLE
Fix freeform object schema rendering for OpenAPI 2.0

### DIFF
--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -104,7 +104,7 @@ def convert_json_schema(schema, directive=':<json'):
 
         type_ = schema.get('type', 'any')
         required_properties = schema.get('required', ())
-        if type_ == 'object':
+        if type_ == 'object' and schema.get('properties'):
             for prop, next_schema in schema.get('properties', {}).items():
                 _convert(
                     next_schema, '{name}.{prop}'.format(**locals()),


### PR DESCRIPTION
Fix rendering of `type: 'object'` schema fields missing `properties` specification. (They were basically ignored.)