### PR TITLE
Preserve order of groups as defined in yaml file

### DIFF
--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -371,12 +371,13 @@ def openapihttpdomain(spec, **options):
 
     # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#paths-object
     if 'group' in options:
-        groups = collections.defaultdict(list)
+        groups = collections.OrderedDict()
+        groups.update({x['name']: [] for x in spec.get('tags', {})})
 
         for endpoint in options.get('paths', spec['paths']):
             for method, properties in spec['paths'][endpoint].items():
                 key = properties.get('tags', [''])[0]
-                groups[key].append(_httpresource(
+                groups.setdefault(key, []).append(_httpresource(
                     endpoint,
                     method,
                     properties,
@@ -384,7 +385,7 @@ def openapihttpdomain(spec, **options):
                     render_examples='examples' in options,
                     render_request=render_request))
 
-        for key in sorted(groups.keys()):
+        for key in groups.keys():
             if key:
                 generators.append(_header(key))
             else:

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -371,8 +371,9 @@ def openapihttpdomain(spec, **options):
 
     # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#paths-object
     if 'group' in options:
-        groups = collections.OrderedDict()
-        groups.update({x['name']: [] for x in spec.get('tags', {})})
+        groups = collections.OrderedDict(
+            [(x['name'], []) for x in spec.get('tags', {})]
+            )
 
         for endpoint in options.get('paths', spec['paths']):
             for method, properties in spec['paths'][endpoint].items():

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -453,6 +453,10 @@ class TestOpenApi3HttpDomain(object):
     def test_groups(self):
         text = '\n'.join(openapi30.openapihttpdomain({
             'openapi': '3.0.0',
+            'tags': [
+                {'name': 'tags'},
+                {'name': 'pets'},
+            ],
             'paths': collections.OrderedDict([
                 ('/', {
                     'get': {
@@ -544,18 +548,18 @@ class TestOpenApi3HttpDomain(object):
             ]),
         }, group=True))
         assert text == textwrap.dedent('''
-            default
-            =======
+            tags
+            ====
 
-            .. http:get:: /
-               :synopsis: Index
+            .. http:get:: /tags
+               :synopsis: List Tags
 
-               **Index**
+               **List Tags**
 
                ~ some useful description ~
 
                :status 200:
-                  Index
+                  Tags
 
             pets
             ====
@@ -582,18 +586,18 @@ class TestOpenApi3HttpDomain(object):
                :status 200:
                   A Pet
 
-            tags
-            ====
+            default
+            =======
 
-            .. http:get:: /tags
-               :synopsis: List Tags
+            .. http:get:: /
+               :synopsis: Index
 
-               **List Tags**
+               **Index**
 
                ~ some useful description ~
 
                :status 200:
-                  Tags
+                  Index
         ''').lstrip()
 
     def test_required_parameters(self):


### PR DESCRIPTION
When the group option is used, the group names were sorted in alphabetical order.
This PR preserves the order of the groups as they are defined in the tags field or as they appear in the endpoint definitions.