### PR TITLE
Support :group: for OpenAPI 2.0

### DIFF
--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -11,6 +11,7 @@
 
 from __future__ import unicode_literals
 
+import collections
 import itertools
 import re
 
@@ -166,6 +167,12 @@ def is_2xx_response(status):
     return False
 
 
+def _header(title):
+    yield title
+    yield '=' * len(title)
+    yield ''
+
+
 def openapihttpdomain(spec, **options):
     if 'examples' in options:
         raise ValueError(
@@ -219,13 +226,34 @@ def openapihttpdomain(spec, **options):
                     _paths.append(path)
         paths = _paths
 
-    for endpoint in paths:
-        for method, properties in spec['paths'][endpoint].items():
-            generators.append(_httpresource(
-                endpoint,
-                method,
-                properties,
-                utils.get_text_converter(options),
-                ))
+    if 'group' in options:
+        groups = collections.defaultdict(list)
+
+        for endpoint in paths:
+            for method, properties in spec['paths'][endpoint].items():
+                key = properties.get('tags', [''])[0]
+                groups[key].append(_httpresource(
+                    endpoint,
+                    method,
+                    properties,
+                    utils.get_text_converter(options),
+                    ))
+
+        for key in sorted(groups.keys()):
+            if key:
+                generators.append(_header(key))
+            else:
+                generators.append(_header('default'))
+
+            generators.extend(groups[key])
+    else:
+        for endpoint in paths:
+            for method, properties in spec['paths'][endpoint].items():
+                generators.append(_httpresource(
+                    endpoint,
+                    method,
+                    properties,
+                    utils.get_text_converter(options),
+                    ))
 
     return iter(itertools.chain(*generators))


### PR DESCRIPTION
This adds support for the `:group:` option to the Open API 2.0 half of the code.
