### PR TITLE
OpenAPI 2.0: Allow objects without properties

### DIFF
--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -106,7 +106,7 @@ def convert_json_schema(schema, directive=':<json'):
 
         type_ = schema.get('type', 'any')
         required_properties = schema.get('required', ())
-        if type_ == 'object':
+        if type_ == 'object' and schema.get('properties'):
             for prop, next_schema in schema.get('properties', {}).items():
                 _convert(
                     next_schema, '{name}.{prop}'.format(**locals()),


### PR DESCRIPTION
This makes it possible to use objects without properties. This is sometimes useful when the content is freeform or not known.