### PR TITLE
RIP Python 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,11 @@
 Here you can see the list of changes between each 'sphinxcontrib-openapi'
 release.
 
+0.6.0 (unreleased)
+==================
+
+- Drop Python 2.7 support because it reached its end-of-life.
+
 0.5.0 (2019-09-04)
 ==================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os
 
 # Unfortunately, Sphinx doesn't support code highlighting for standard

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import os
 
-from io import open
 from setuptools import setup, find_packages
 
 
@@ -46,9 +44,8 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/sphinxcontrib/openapi/__init__.py
+++ b/sphinxcontrib/openapi/__init__.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
 
 from pkg_resources import get_distribution, DistributionNotFound
 

--- a/sphinxcontrib/openapi/__main__.py
+++ b/sphinxcontrib/openapi/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import argparse
 import logging
 

--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -8,27 +8,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
-
 import collections
-try:
-    from functools import lru_cache as simple_cache
-except ImportError:
-    def simple_cache():
-        def decorate(user_function):
-            cache = dict()
-
-            def wrapper(*args):
-                try:
-                    result = cache[args]
-                except KeyError:
-                    result = user_function(*args)
-                    cache[args] = result
-                return result
-            return wrapper
-        return decorate
-
-import io
+import functools
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -58,9 +39,9 @@ _YamlOrderedLoader.add_constructor(
 
 # Locally cache spec to speedup processing of same spec file in multiple
 # openapi directives
-@simple_cache()
+@functools.lru_cache()
 def _get_spec(abspath, encoding):
-    with io.open(abspath, 'rt', encoding=encoding) as stream:
+    with open(abspath, 'rt', encoding=encoding) as stream:
         return yaml.load(stream, _YamlOrderedLoader)
 
 

--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
-
 import collections
 import itertools
 import re

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -8,25 +8,19 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
-
 import copy
 import collections
 from datetime import datetime
 import itertools
 import json
 import re
+from urllib import parse
+from http.client import responses as http_status_codes
 
-import six
-from six.moves.urllib import parse
 from sphinx.util import logging
 
 from sphinxcontrib.openapi import utils
 
-try:
-    from httplib import responses as http_status_codes  # python2
-except ImportError:
-    from http.client import responses as http_status_codes  # python3
 
 LOG = logging.getLogger(__name__)
 
@@ -194,7 +188,7 @@ def _example(media_type_objects, method=None, endpoint=None, status=None,
                 }
 
         for example in examples.values():
-            if not isinstance(example['value'], six.string_types):
+            if not isinstance(example['value'], str):
                 example['value'] = json.dumps(
                     example['value'], indent=4, separators=(',', ': '))
 

--- a/sphinxcontrib/openapi/utils.py
+++ b/sphinxcontrib/openapi/utils.py
@@ -8,8 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
-
 import collections
 
 import jsonschema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import textwrap
 import pytest
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -8,8 +8,6 @@
     :license: BSD, see LICENSE for details.
 """
 
-from __future__ import unicode_literals
-
 import os
 import textwrap
 import collections

--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -1,7 +1,5 @@
 """Smoke test examples from OAI/OpenAPI-Specification repo."""
 
-from __future__ import unicode_literals
-
 import os
 import glob
 import itertools

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py2, py3, docs
+envlist = py, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Rest in piece, Python 2. You served us well. Jokes aside, Sphinx >= 2
does not support Python 2, and, from now on, and so we are.