### PR TITLE
Add renderers concept

### DIFF
--- a/sphinxcontrib/openapi/__main__.py
+++ b/sphinxcontrib/openapi/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from sphinxcontrib.openapi import directive
+from sphinxcontrib.openapi import directive, renderers
 
 
 def main():
@@ -58,13 +58,12 @@ def main():
         openapi_options['examples'] = True
     if options.group:
         openapi_options['group'] = True
-    openapihttpdomain, spec = \
-        directive.get_openapihttpdomain(
-            openapi_options,
-            options.input,
-            options.encoding)
 
-    for line in openapihttpdomain(spec, **openapi_options):
+    openapi_options.setdefault('uri', 'file://%s' % options.input)
+    spec = directive._get_spec(options.input, options.encoding)
+    renderer = renderers.HttpdomainOldRenderer(None, openapi_options)
+
+    for line in renderer.render_restructuredtext_markup(spec):
         options.output.write(line+'\n')
         logging.debug(line)
 

--- a/sphinxcontrib/openapi/directive.py
+++ b/sphinxcontrib/openapi/directive.py
@@ -11,15 +11,9 @@
 import collections
 import functools
 
-from docutils import nodes
-from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import ViewList
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
 import yaml
-
-from sphinx.util.nodes import nested_parse_with_titles
-
-from sphinxcontrib.openapi import openapi20
-from sphinxcontrib.openapi import openapi30
 
 
 # Dictionaries do not guarantee to preserve the keys order so when we load
@@ -45,69 +39,36 @@ def _get_spec(abspath, encoding):
         return yaml.load(stream, _YamlOrderedLoader)
 
 
-def get_openapihttpdomain(options, abspath, encoding):
-    spec = _get_spec(abspath, encoding)
+def create_directive_from_renderer(renderer_cls):
+    """Create rendering directive from a renderer class."""
 
-    # URI parameter is crucial for resolving relative references. So
-    # we need to set this option properly as it's used later down the
-    # stack.
-    options.setdefault('uri', 'file://%s' % abspath)
+    class _RenderingDirective(SphinxDirective):
+        required_arguments = 1                  # path to openapi spec
+        final_argument_whitespace = True        # path may contain whitespaces
+        option_spec = dict(
+            {
+                'encoding': directives.encoding,    # useful for non-ascii cases :)
+            },
+            **renderer_cls.option_spec
+        )
 
-    # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
-    # determine which version we are parsing here.
-    spec_version = spec.get('openapi', spec.get('swagger', '2.0'))
-    if spec_version.startswith('2.'):
-        openapihttpdomain = openapi20.openapihttpdomain
-    elif spec_version.startswith('3.'):
-        openapihttpdomain = openapi30.openapihttpdomain
-    else:
-        raise ValueError('Unsupported OpenAPI version (%s)' % spec_version)
-    return openapihttpdomain, spec
+        def run(self):
+            relpath, abspath = self.env.relfn2path(directives.path(self.arguments[0]))
 
+            # URI parameter is crucial for resolving relative references. So we
+            # need to set this option properly as it's used later down the
+            # stack.
+            self.options.setdefault('uri', 'file://%s' % abspath)
 
-class OpenApi(Directive):
+            # Add a given OpenAPI spec as a dependency of the referring
+            # reStructuredText document, so the document is rebuilt each time
+            # the spec is changed.
+            self.env.note_dependency(relpath)
 
-    required_arguments = 1                  # path to openapi spec
-    final_argument_whitespace = True        # path may contain whitespaces
-    option_spec = {
-        'encoding': directives.encoding,    # useful for non-ascii cases :)
-        'paths': lambda s: s.split(),       # endpoints to be rendered
-        'include': lambda s: s.split(),     # endpoints to be included (regexp)
-        'exclude': lambda s: s.split(),     # endpoints to be excluded (regexp)
-        'request': directives.flag,         # print the request body structure
-        'examples': directives.flag,        # render examples when passed
-        'group': directives.flag,           # group paths by tag when passed
-        'format': str,                      # "rst" (default) or "markdown"
-    }
+            # Read the spec using encoding passed to the directive or fallback to
+            # the one specified in Sphinx's config.
+            encoding = self.options.get('encoding', self.config.source_encoding)
+            spec = _get_spec(abspath, encoding)
+            return renderer_cls(self.state, self.options).render(spec)
 
-    def run(self):
-        env = self.state.document.settings.env
-        relpath, abspath = env.relfn2path(directives.path(self.arguments[0]))
-
-        # Add OpenAPI spec as a dependency to the current document. That means
-        # the document will be rebuilt if the spec is changed.
-        env.note_dependency(relpath)
-
-        # Read the spec using encoding passed to the directive or fallback to
-        # the one specified in Sphinx's config.
-        encoding = self.options.get('encoding', env.config.source_encoding)
-
-        # Open the specification file
-        openapihttpdomain, spec = \
-            get_openapihttpdomain(self.options, abspath, encoding)
-
-        # reStructuredText DOM manipulation is pretty tricky task. It requires
-        # passing dozen arguments which is not easy without well-documented
-        # internals. So the idea here is to represent OpenAPI spec as
-        # reStructuredText in-memory text and parse it in order to produce a
-        # real DOM.
-        viewlist = ViewList()
-        for line in openapihttpdomain(spec, **self.options):
-            viewlist.append(line, '<openapi>')
-
-        # Parse reStructuredText contained in `viewlist` and return produced
-        # DOM nodes.
-        node = nodes.section()
-        node.document = self.state.document
-        nested_parse_with_titles(self.state, viewlist, node)
-        return node.children
+    return _RenderingDirective

--- a/sphinxcontrib/openapi/renderers/__init__.py
+++ b/sphinxcontrib/openapi/renderers/__init__.py
@@ -1,0 +1,10 @@
+"""Here lies OpenAPI renderers."""
+
+from . import abc
+from ._httpdomain_old import HttpdomainOldRenderer
+
+
+__all__ = [
+    "abc",
+    "HttpdomainOldRenderer",
+]

--- a/sphinxcontrib/openapi/renderers/_httpdomain_old.py
+++ b/sphinxcontrib/openapi/renderers/_httpdomain_old.py
@@ -1,0 +1,52 @@
+"""Here lies still breathing and only renderer implementation."""
+
+from docutils.parsers.rst import directives
+
+from . import abc
+from .. import openapi20, openapi30, utils
+
+
+class HttpdomainOldRenderer(abc.RestructuredTextRenderer):
+
+    option_spec = {
+        # A list of endpoints to be rendered. Endpoints must be whitespace
+        # delimited.
+        "paths": lambda s: s.split(),
+        # Regular expression patterns to includes/excludes endpoints to/from
+        # rendering. Similar to paths, the patterns must be whitespace
+        # delimited.
+        "include": lambda s: s.split(),
+        "exclude": lambda s: s.split(),
+        # Render the request body structure when passed.
+        "request": directives.flag,
+        # Render request/response examples when passed.
+        "examples": directives.flag,  # render examples when passed
+        # Group endpoints by tags when passed. By default, no grouping is
+        # applied and endpoints are rendered in the order they met in spec.
+        "group": directives.flag,
+        # Markup format to render OpenAPI descriptions.
+        "format": str,
+    }
+
+    def __init__(self, state, options):
+        self._state = state
+        self._options = options
+
+    def render_restructuredtext_markup(self, spec):
+        # OpenAPI spec may contain JSON references, common properties, etc.
+        # Trying to render the spec "As Is" will require to put multiple if-s
+        # around the code. In order to simplify rendering flow, let's make it
+        # have only one (expected) schema, i.e. normalize it.
+        utils.normalize_spec(spec, **self._options)
+
+        # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
+        # determine which version we are parsing here.
+        spec_version = spec.get("openapi", spec.get("swagger", "2.0"))
+        if spec_version.startswith("2."):
+            openapihttpdomain = openapi20.openapihttpdomain
+        elif spec_version.startswith("3."):
+            openapihttpdomain = openapi30.openapihttpdomain
+        else:
+            raise ValueError("Unsupported OpenAPI version (%s)" % spec_version)
+
+        yield from openapihttpdomain(spec, **self._options)

--- a/sphinxcontrib/openapi/renderers/abc.py
+++ b/sphinxcontrib/openapi/renderers/abc.py
@@ -1,0 +1,46 @@
+"""Abstract Base Classes (ABCs) for OpenAPI renderers."""
+
+import abc
+
+from docutils import nodes
+from docutils.statemachine import ViewList
+from sphinx.util.nodes import nested_parse_with_titles
+
+
+class Renderer(metaclass=abc.ABCMeta):
+    """Base class for OpenAPI renderers."""
+
+    def __init__(self, state, options):
+        self._state = state
+        self._options = options
+
+    @property
+    @abc.abstractmethod
+    def option_spec(self):
+        """Renderer options and their converting functions."""
+
+    @abc.abstractmethod
+    def render(self, spec):
+        """Render a given OpenAPI spec."""
+
+
+class RestructuredTextRenderer(Renderer):
+    """Base class for reStructuredText OpenAPI renderers.
+
+    Docutils DOM manipulation is quite a tricky task that requires passing
+    dozen arguments around. Because of that a lot of Sphinx extensions instead
+    of constructing DOM nodes directly produce and parse reStructuredText.
+    This Sphinx extension is not an exception, and that's why this class
+    exists. It's a convenient extension of :class:`Renderer` that converts
+    produced markup text into docutils DOM elements.
+    """
+
+    def render(self, spec):
+        viewlist = ViewList()
+        for line in self.render_restructuredtext_markup(spec):
+            viewlist.append(line, "<openapi>")
+
+        node = nodes.section()
+        node.document = self._state.document
+        nested_parse_with_titles(self._state, viewlist, node)
+        return node.children

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -15,15 +15,16 @@ import collections
 import py
 import pytest
 
+from sphinxcontrib.openapi import renderers
 from sphinxcontrib.openapi import openapi20
-from sphinxcontrib.openapi import openapi30
 from sphinxcontrib.openapi import utils
 
 
 class TestOpenApi2HttpDomain(object):
 
     def test_basic(self):
-        text = '\n'.join(openapi20.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'paths': {
                 '/resources/{kind}': {
                     'get': {
@@ -86,7 +87,8 @@ class TestOpenApi2HttpDomain(object):
         ''').lstrip()
 
     def test_groups(self):
-        text = '\n'.join(openapi20.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {'group': True})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'tags': [
                 {'name': 'tags'},
                 {'name': 'pets'},
@@ -180,7 +182,7 @@ class TestOpenApi2HttpDomain(object):
                     },
                 }),
             ]),
-        }, group=True))
+        }))
         assert text == textwrap.dedent('''
             tags
             ====
@@ -253,7 +255,8 @@ class TestOpenApi2HttpDomain(object):
             }
         }
 
-        text = '\n'.join(openapi20.openapihttpdomain(spec))
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup(spec))
         assert text == textwrap.dedent('''
             .. http:get:: /resource_a
                :synopsis: null
@@ -291,9 +294,10 @@ class TestOpenApi2HttpDomain(object):
             }
         }
 
-        text = '\n'.join(openapi20.openapihttpdomain(spec, paths=[
+        renderer = renderers.HttpdomainOldRenderer(None, {'paths': [
             '/resource_a',
-        ]))
+        ]})
+        text = '\n'.join(renderer.render_restructuredtext_markup(spec))
         assert text == textwrap.dedent('''
             .. http:get:: /resource_a
                :synopsis: null
@@ -323,9 +327,10 @@ class TestOpenApi2HttpDomain(object):
             }
         }
 
-        text = '\n'.join(openapi20.openapihttpdomain(spec, include=[
+        renderer = renderers.HttpdomainOldRenderer(None, {'include': [
             '/resource',
-        ]))
+        ]})
+        text = '\n'.join(renderer.render_restructuredtext_markup(spec))
         assert text == textwrap.dedent('''
             .. http:get:: /resource_a
                :synopsis: null
@@ -363,9 +368,10 @@ class TestOpenApi2HttpDomain(object):
             }
         }
 
-        text = '\n'.join(openapi20.openapihttpdomain(spec, exclude=[
+        renderer = renderers.HttpdomainOldRenderer(None, {'exclude': [
             '/.*_a',
-        ]))
+        ]})
+        text = '\n'.join(renderer.render_restructuredtext_markup(spec))
         assert text == textwrap.dedent('''
             .. http:post:: /resource_b
                :synopsis: null
@@ -407,7 +413,8 @@ class TestOpenApi2HttpDomain(object):
             },
         }
 
-        text = '\n'.join(openapi20.openapihttpdomain(spec))
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup(spec))
 
         assert text == textwrap.dedent('''
             .. http:get:: /resources/{name}
@@ -454,11 +461,13 @@ class TestOpenApi2HttpDomain(object):
             }
         }
 
+        renderer = renderers.HttpdomainOldRenderer(None, {'paths': [
+            '/resource_a',
+            '/resource_invalid_name',
+        ]})
+
         with pytest.raises(ValueError) as exc:
-            openapi20.openapihttpdomain(spec, paths=[
-                '/resource_a',
-                '/resource_invalid_name',
-            ])
+            '\n'.join(renderer.render_restructuredtext_markup(spec))
 
         assert str(exc.value) == (
             'One or more paths are not defined in the spec: '
@@ -479,7 +488,8 @@ class TestOpenApi2HttpDomain(object):
             }
         }
 
-        text = '\n'.join(openapi20.openapihttpdomain(spec))
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup(spec))
 
         assert text == textwrap.dedent('''
             .. http:get:: /resource_a
@@ -492,7 +502,8 @@ class TestOpenApi2HttpDomain(object):
         ''').lstrip()
 
     def test_json_in_out(self):
-        text = '\n'.join(openapi20.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'definitions': {
                 'CreateResourceSchema': {
                     'additionalProperties': False,
@@ -603,7 +614,8 @@ class TestOpenApi2HttpDomain(object):
 class TestOpenApi3HttpDomain(object):
 
     def test_basic(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'paths': {
                 '/resources/{kind}': {
@@ -670,7 +682,8 @@ class TestOpenApi3HttpDomain(object):
         ''').lstrip()
 
     def test_groups(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {'group': True})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'tags': [
                 {'name': 'tags'},
@@ -765,7 +778,7 @@ class TestOpenApi3HttpDomain(object):
                     },
                 }),
             ]),
-        }, group=True))
+        }))
         assert text == textwrap.dedent('''
             tags
             ====
@@ -820,7 +833,8 @@ class TestOpenApi3HttpDomain(object):
         ''').lstrip()
 
     def test_required_parameters(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'paths': {
                 '/resources/{kind}': {
@@ -891,7 +905,8 @@ class TestOpenApi3HttpDomain(object):
         ''').lstrip()
 
     def test_example_generation(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {'examples': True})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'paths': collections.OrderedDict([
                 ('/resources/', collections.OrderedDict([
@@ -1045,8 +1060,7 @@ class TestOpenApi3HttpDomain(object):
                     },
                 },
             },
-        },
-        examples=True))
+        }))
 
         assert text == textwrap.dedent('''
             .. http:get:: /resources/
@@ -1204,7 +1218,8 @@ class TestOpenApi3HttpDomain(object):
         ''').lstrip()
 
     def test_get_example_with_explode(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {'examples': True})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'paths': collections.OrderedDict([
                 ('/resources/', collections.OrderedDict([
@@ -1255,7 +1270,7 @@ class TestOpenApi3HttpDomain(object):
                     }),
                 ])),
             ]),
-        }, examples=True))
+        }))
 
         assert text == textwrap.dedent('''
             .. http:get:: /resources/
@@ -1284,7 +1299,8 @@ class TestOpenApi3HttpDomain(object):
         ''').lstrip()
 
     def test_callback(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'paths': {
                 '/resources/{kind}': {
@@ -1448,7 +1464,8 @@ class TestResolveRefs(object):
         }
 
     def test_noproperties(self):
-        text = '\n'.join(openapi30.openapihttpdomain({
+        renderer = renderers.HttpdomainOldRenderer(None, {'examples': True})
+        text = '\n'.join(renderer.render_restructuredtext_markup({
             'openapi': '3.0.0',
             'paths': {
                 '/resources': {
@@ -1481,7 +1498,7 @@ class TestResolveRefs(object):
                 },
             },
 
-        }, examples=True))
+        }))
         assert text == textwrap.dedent('''
             .. http:post:: /resources
                :synopsis: Create Resources

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,6 @@ commands =
 deps = sphinx_rtd_theme
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees docs docs/_build/
+
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
The renderers in sphinxcontrib-openapi are the entities that render
OpenAPI spec. Each render may have its own set of options, and its own
rendering rules. So far we have only a single render but we believe this
is a way to go, as it allows to come up with better new implementations
without breaking changes.