### PR TITLE
Actualize information in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ reinvent the wheel.
 
 .. code:: bash
 
-   pip install sphinxcontrib-openapi
+   $ python3 -m pip install sphinxcontrib-openapi
 
 
 Usage
@@ -35,8 +35,8 @@ Links
 =====
 
 * Documentation: https://sphinxcontrib-openapi.readthedocs.org/
-* Source: https://github.com/ikalnytskyi/sphinxcontrib-openapi
-* Bugs: https://github.com/ikalnytskyi/sphinxcontrib-openapi/issues
+* Source: https://github.com/sphinx-contrib/openapi
+* Bugs: https://github.com/sphinx-contrib/openapi/issues
 
 
 .. _Sphinx: https://www.sphinx-doc.org/en/master/

--- a/setup.py
+++ b/setup.py
@@ -16,29 +16,34 @@ setup(
     description='OpenAPI (fka Swagger) spec renderer for Sphinx',
     long_description=long_description,
     license='BSD',
-    url='https://github.com/ikalnytskyi/sphinxcontrib-openapi',
+    url='https://github.com/sphinx-contrib/openapi',
     keywords='sphinx openapi swagger rest api renderer docs',
     author='Ihor Kalnytskyi',
     author_email='ihor@kalnytskyi.com',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    use_scm_version=True,
+    use_scm_version={
+        'root': here,
+    },
     setup_requires=[
         'setuptools_scm >= 1.15',
     ],
     install_requires=[
+        'sphinx >= 2.0',
         'sphinxcontrib-httpdomain >= 1.5.0',
         'PyYAML >= 3.12',
         'jsonschema >= 2.5.1',
+        'm2r >= 0.2',
     ],
-    extras_require={
-        'markdown': [
-            'm2r',
-        ],
+    project_urls={
+        'Documentation': 'https://sphinxcontrib-openapi.readthedocs.io/',
+        'Source': 'https://github.com/sphinx-contrib/openapi',
+        'Bugs': 'https://github.com/sphinx-contrib/openapi/issues',
     },
     classifiers=[
         'Topic :: Documentation',
+        'Topic :: Documentation :: Sphinx',
         'License :: OSI Approved :: BSD License',
         'Environment :: Console',
         'Intended Audience :: Developers',
@@ -50,6 +55,11 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Framework :: Setuptools Plugin',
+        'Framework :: Sphinx',
+        'Framework :: Sphinx :: Extension',
     ],
     namespace_packages=['sphinxcontrib'],
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
Apparently, links weren't updated after the project has been transferred
to sphinx-contrib organization. And since it happened that we need to
update them anyway, let's also update other information such as:

 * classifiers
 * project links
 * dependency pinnings

The requirement for Sphinx >= 2.x should has been pinned since dropping
Python 2 support, but due to a rush it's never happened. :(