### PR TITLE
Show description for arrays of string, number, integer or boolean

### DIFF
--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -111,7 +111,15 @@ def convert_json_schema(schema, directive=':<json'):
                     (prop in required_properties))
 
         elif type_ == 'array':
-            _convert(schema['items'], name + '[]')
+            if schema['items'].get('type', 'any') in ['string', 'number', 'integer', 'boolean']:
+                name = name.lstrip('.')
+                description = schema.get('description', '')
+                output.append((
+                    name,
+                    '{type_} {name}:'
+                    ' {description}'.format(**locals())))
+            else:
+                _convert(schema['items'], name + '[]')
 
         else:
             if name:


### PR DESCRIPTION
This will generate descriptions for arrays of string, number, integer or boolean. Before they didn't appear on generated output.