### PR TITLE
Add OAS 2 -> 3 converter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "PyYAML >= 3.12",
         "jsonschema >= 2.5.1",
         "m2r >= 0.2",
+        "picobox >= 2.2",
     ],
     project_urls={
         "Documentation": "https://sphinxcontrib-openapi.readthedocs.io/",

--- a/sphinxcontrib/openapi/_lib2to3.py
+++ b/sphinxcontrib/openapi/_lib2to3.py
@@ -1,0 +1,378 @@
+"""Partial OpenAPI v2.x (fka Swagger) to OpenAPI v3.x converter."""
+
+import functools
+import urllib
+
+import picobox
+
+
+__all__ = [
+    "convert",
+]
+
+
+def convert(spec):
+    """Convert a given OAS 2 spec to OAS 3."""
+
+    return Lib2to3().convert(spec)
+
+
+def _is_vendor_extension(key):
+    """Return 'True' if a given key is a vendor extension."""
+
+    return key.startswith("x-")
+
+
+def _get_properties(node, properties, *, vendor_extensions=False):
+    """Return a subset of 'node' properties w/ or wo/ vendor extensions."""
+
+    return {
+        key: value
+        for key, value in node.items()
+        if any([key in properties, vendor_extensions and _is_vendor_extension(key)])
+    }
+
+
+def _get_schema_properties(node, *, except_for=None):
+    """Find and return 'Schema Object' properties."""
+
+    except_for = except_for or set()
+    schema = _get_properties(
+        node,
+        {
+            "additionalProperties",
+            "allOf",
+            "default",
+            "description",
+            "discriminator",
+            "enum",
+            "example",
+            "exclusiveMaximum",
+            "exclusiveMinimum",
+            "externalDocs",
+            "format",
+            "items",
+            "maxItems",
+            "maxLength",
+            "maxProperties",
+            "maximum",
+            "minItems",
+            "minLength",
+            "minProperties",
+            "minimum",
+            "multipleOf",
+            "pattern",
+            "properties",
+            "readOnly",
+            "required",
+            "title",
+            "type",
+            "uniqueItems",
+            "xml",
+        }
+        - set(except_for),
+    )
+
+    if "discriminator" in schema:
+        schema["discriminator"] = {"propertyName": schema["discriminator"]}
+    return schema
+
+
+def _items_wo_vendor_extensions(node):
+    """Iterate over 'node' properties excluding vendor extensions."""
+
+    for key, value in node.items():
+        if _is_vendor_extension(key):
+            continue
+        yield key, value
+
+
+class Lib2to3:
+
+    _target_version = "3.0.3"
+    _injector = picobox.Stack()
+
+    def _insert_into_injector(name):
+        def decorator(fn):
+            @functools.wraps(fn)
+            def wrapper(self, node, *args, **kwargs):
+                with Lib2to3._injector.push(picobox.Box(), chain=True) as box:
+                    box.put(name, factory=lambda: node, scope=picobox.threadlocal)
+                    return fn(self, node, *args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    def __init__(self):
+        self._schemes = set()
+
+    @_insert_into_injector("spec")
+    def convert(self, spec):
+        # The following OAS 2 fields are ignored and not converted. Mostly due
+        # to the fact that we expect *resolved* spec as input, and most of its
+        # fields are used to group shared (i.e. referenced) objects that will
+        # not exist in the resolved spec.
+        #
+        #  - definitions
+        #  - parameters
+        #  - responses
+        #  - securityDefinitions
+        #  - security
+        #
+        # By no means one must assume that these fields will never be
+        # converted. I simply have no time to work on this, and for
+        # sphixcontrib-openapi purposes it's not actually needed.
+
+        converted = {
+            "info": spec["info"],
+            "openapi": self._target_version,
+            "paths": self.convert_paths(spec["paths"]),
+        }
+        converted.update(
+            _get_properties(spec, {"tags", "externalDocs"}, vendor_extensions=True),
+        )
+
+        servers = self.convert_servers(spec)
+        if servers:
+            converted["servers"] = servers
+
+        return converted
+
+    @_insert_into_injector("paths")
+    def convert_paths(self, paths):
+        converted = _get_properties(paths, {}, vendor_extensions=True)
+
+        for endpoint, path in _items_wo_vendor_extensions(paths):
+            converted[endpoint] = self.convert_path(path)
+
+        return converted
+
+    @_insert_into_injector("path")
+    def convert_path(self, path):
+        converted = _get_properties(path, {}, vendor_extensions=True)
+
+        for key, value in _items_wo_vendor_extensions(path):
+            if key == "parameters":
+                converted[key] = self.convert_parameters(value)
+            else:
+                converted[key] = self.convert_operation(value)
+
+        return converted
+
+    @_insert_into_injector("operation")
+    def convert_operation(self, operation):
+        converted = _get_properties(
+            operation,
+            {
+                "tags",
+                "summary",
+                "description",
+                "externalDocs",
+                "operationId",
+                "deprecated",
+                "security",
+            },
+            vendor_extensions=True,
+        )
+
+        # Memorize every encountered 'schemes'. Since this property does not
+        # exist in OAS 3, it seems the best we can do is to use them in OAS 3
+        # 'servers' object.
+        self._schemes.update(operation.get("schemes", []))
+
+        if "parameters" in operation:
+            parameters = self.convert_parameters(operation["parameters"])
+
+            # Both 'body' and 'formData' parameters are mutually exclusive,
+            # therefore there's no way we may end up with both kinds at once.
+            request_body = self.convert_request_body(operation)
+            request_body = request_body or self.convert_request_body_formdata(operation)
+
+            if parameters:
+                converted["parameters"] = parameters
+
+            if request_body:
+                converted["requestBody"] = request_body
+
+        converted["responses"] = self.convert_responses(operation["responses"])
+        return converted
+
+    @_injector.pass_("spec")
+    def convert_request_body(self, operation, *, spec):
+        # OAS 3 expects an explicitly specified mimetype of the request body.
+        # It's not clear what to do if OAS 2 'consumes' is not defined. Let's
+        # start with a glob pattern and figure out what a better option could
+        # be later on.
+        consumes = operation.get("consumes") or spec.get("consumes") or ["*/*"]
+
+        for parameter in operation["parameters"]:
+            if parameter["in"] == "body":
+                # Since 'requestBody' is completely new and nested object in
+                # OAS 3, it's not clear what should we insert possible vendor
+                # extensions. Thus, let's ignore them until we figure it out.
+                converted = _get_properties(parameter, {"description", "required"})
+                converted["content"] = {
+                    consume: {"schema": parameter["schema"]} for consume in consumes
+                }
+                return converted
+
+        return None
+
+    @_injector.pass_("spec")
+    def convert_request_body_formdata(self, operation, *, spec):
+        consumes = (
+            operation.get("consumes")
+            or spec.get("consumes")
+            or ["application/x-www-form-urlencoded"]
+        )
+        supported = {
+            "application/x-www-form-urlencoded",
+            "multipart/form-data",
+        }
+        mimetypes = supported.intersection(consumes)
+        schema = {"type": "object", "properties": {}}
+
+        for parameter in operation["parameters"]:
+            if parameter["in"] == "formData":
+                schema["properties"][parameter["name"]] = _get_schema_properties(
+                    parameter, except_for={"name", "in", "required"}
+                )
+
+                if parameter.get("required"):
+                    schema.setdefault("required", []).append(parameter["name"])
+
+                # Excerpt from OpenAPI 2.x spec:
+                #
+                # > If type is "file", the consumes MUST be either
+                # > "multipart/form-data", "application/x-www-form-urlencoded"
+                # > or both and the parameter MUST be in "formData".
+                #
+                # This is weird since HTTP does not allow file uploading in
+                # 'application/x-www-form-urlencoded'. Moreover, Swagger
+                # editor complains if 'file' is detected and there's no
+                # 'multipart/form-data' in `consumes'.
+                if parameter["type"] == "file":
+                    mimetypes = ["multipart/form-data"]
+
+        if not schema["properties"]:
+            return None
+        return {"content": {mimetype: {"schema": schema} for mimetype in mimetypes}}
+
+    @_insert_into_injector("parameters")
+    def convert_parameters(self, parameters):
+        return [
+            self.convert_parameter(parameter)
+            for parameter in parameters
+            # If a parameter is one of the backward compatible type, delegate
+            # the call to the converter function. Incompatible types, such as
+            # 'formData' and 'body', must be handled separately since they are
+            # reflected in 'Operation Object' in OAS 3.
+            if parameter["in"] in {"query", "header", "path"}
+        ]
+
+    @_insert_into_injector("parameter")
+    def convert_parameter(self, parameter):
+        schema = _get_schema_properties(
+            parameter,
+            # Some of 'Parameter Object' properties have the same name as some
+            # of 'Schema Object' properties. Since we know for sure that in
+            # this context they are part of 'Parameter Object', we should
+            # ignore their meaning as part of 'Schema Object'.
+            except_for={"name", "in", "description", "required"},
+        )
+        converted = {
+            key: value for key, value in parameter.items() if key not in schema
+        }
+        converted["schema"] = schema
+        collection_format = converted.pop("collectionFormat", None)
+
+        if converted["in"] in {"path", "header"} and collection_format == "csv":
+            converted["style"] = "simple"
+        elif converted["in"] in {"query"} and collection_format:
+            styles = {
+                "csv": {"style": "form", "explode": False},
+                "multi": {"style": "form", "explode": True},
+                "ssv": {"style": "spaceDelimited"},
+                "pipes": {"style": "pipeDelimited"},
+                # OAS 3 does not explicitly say what is the alternative to
+                # 'collectionFormat=tsv'. We have no other option but to ignore
+                # it. Fortunately, we don't care much as it's not used by the
+                # renderer.
+                "tsv": {},
+            }
+            converted.update(styles[collection_format])
+
+        return converted
+
+    @_insert_into_injector("responses")
+    def convert_responses(self, responses):
+        converted = _get_properties(responses, {}, vendor_extensions=True)
+
+        for status_code, response in _items_wo_vendor_extensions(responses):
+            converted[status_code] = self.convert_response(response)
+
+        return converted
+
+    @_injector.pass_("spec")
+    @_injector.pass_("operation")
+    @_insert_into_injector("response")
+    def convert_response(self, response, *, spec, operation):
+        converted = _get_properties(response, {"description"}, vendor_extensions=True)
+
+        # OAS 3 expects an explicitly specified mimetype in the response. It's
+        # not clear what to do if OAS 2 'produces' is not defined. Let's start
+        # with a glob pattern and figure out what a better option could be
+        # later on.
+        produces = operation.get("produces") or spec.get("produces") or ["*/*"]
+        schema = response.get("schema")
+        examples = response.get("examples")
+
+        if schema or examples:
+            content = converted.setdefault("content", {})
+
+            if schema is not None:
+                for mimetype in produces:
+                    content.setdefault(mimetype, {})["schema"] = schema
+
+            if examples is not None:
+                # According to OAS2, mimetypes in 'examples' property MUST be
+                # one of the operation's 'produces'.
+                for mimetype, example in examples.items():
+                    content.setdefault(mimetype, {})["example"] = example
+
+        if "headers" in response:
+            converted["headers"] = {
+                key: dict(
+                    _get_properties(value, "description", vendor_extensions=True),
+                    schema=_get_schema_properties(value, except_for={"description"}),
+                )
+                for key, value in response["headers"].items()
+            }
+
+        return converted
+
+    def convert_servers(self, spec):
+        """Convert OAS2 '(host, basePath, schemes)' triplet into OAS3 'servers' node."""
+
+        host = spec.get("host", "")
+        basepath = spec.get("basePath", "")
+        schemes = self._schemes.union(spec.get("schemes", set()))
+
+        # Since 'host', 'basePath' and 'schemes' are optional in OAS 2, there
+        # may be the case when they aren't set. If that's happened it means
+        # there's nothing to convert, and thus we simply return an empty list.
+        if not host and not basepath and not schemes:
+            return []
+
+        if not schemes:
+            # If 'host' is not set, the url will contain a bare basePath.
+            # According to OAS 3, it's a valid URL, and both the host and the
+            # scheme must be assumed to be the same as the server that shared
+            # this OAS 3 spec.
+            return [{"url": urllib.parse.urljoin(host, basepath)}]
+
+        return [
+            {"url": urllib.parse.urlunsplit([scheme, host, basepath, None, None])}
+            for scheme in sorted(schemes)
+        ]

--- a/tests/lib2to3/conftest.py
+++ b/tests/lib2to3/conftest.py
@@ -1,0 +1,12 @@
+import textwrap
+
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="function")
+def oas_fragment():
+    def oas_fragment(fragment):
+        return yaml.safe_load(textwrap.dedent(fragment))
+
+    return oas_fragment

--- a/tests/lib2to3/test_convert.py
+++ b/tests/lib2to3/test_convert.py
@@ -1,0 +1,506 @@
+""".convert() test suite."""
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+def test_minimal(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_complete(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            tags:
+              - tag_a
+            externalDocs: https://docs.example.com/
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        tags:
+          - tag_a
+        externalDocs: https://docs.example.com/
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_servers_complete(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            host: example.com
+            basePath: /v1
+            schemes:
+              - https
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        servers:
+          - url: https://example.com/v1
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_servers_host_only(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            host: example.com
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        servers:
+          - url: example.com
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_servers_basepath_only(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            basePath: /v1
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        servers:
+          - url: /v1
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_servers_schemes_multiple(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            host: example.com
+            schemes:
+              - http
+              - https
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        servers:
+          - url: http://example.com
+          - url: https://example.com
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_servers_schemes_from_operation(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            host: example.com
+            schemes:
+              - http
+            paths:
+              /test:
+                get:
+                  schemes:
+                    - ws
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        servers:
+          - url: http://example.com
+          - url: ws://example.com
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        """
+    )
+
+
+def test_consumes(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            consumes:
+              - application/json
+            paths:
+              /test:
+                post:
+                  parameters:
+                    - in: query
+                      name: marker
+                      type: string
+                    - in: body
+                      name: payload
+                      schema:
+                        type: string
+                  responses:
+                    '201':
+                      description: a response description
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        paths:
+          /test:
+            post:
+              parameters:
+                - in: query
+                  name: marker
+                  schema:
+                    type: string
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      type: string
+              responses:
+                '201':
+                  description: a response description
+        """
+    )
+
+
+def test_consumes_operation_override(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            consumes:
+              - application/xml
+            paths:
+              /test:
+                post:
+                  consumes:
+                    - application/json
+                  parameters:
+                    - in: query
+                      name: marker
+                      type: string
+                    - in: body
+                      name: payload
+                      schema:
+                        type: string
+                  responses:
+                    '201':
+                      description: a response description
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        paths:
+          /test:
+            post:
+              parameters:
+                - in: query
+                  name: marker
+                  schema:
+                    type: string
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      type: string
+              responses:
+                '201':
+                  description: a response description
+        """
+    )
+
+
+def test_produces(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            produces:
+              - application/json
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      schema:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      description: a response description
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  content:
+                    application/json:
+                      schema:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                  description: a response description
+        """
+    )
+
+
+def test_produces_operation_override(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            produces:
+              - application/xml
+            paths:
+              /test:
+                get:
+                  produces:
+                    - application/json
+                  responses:
+                    '200':
+                      schema:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      description: a response description
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  content:
+                    application/json:
+                      schema:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                  description: a response description
+        """
+    )
+
+
+def test_vendor_extensions(oas_fragment):
+    converted = lib2to3.convert(
+        oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: 1.0
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            x-vendor-ext: vendor-ext
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        openapi: 3.0.3
+        info:
+          title: An example spec
+          version: 1.0
+        paths:
+          /test:
+            get:
+              responses:
+                '200':
+                  description: a response description
+        x-vendor-ext: vendor-ext
+        """
+    )

--- a/tests/lib2to3/test_convert_operation.py
+++ b/tests/lib2to3/test_convert_operation.py
@@ -1,0 +1,281 @@
+""".convert_operation() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_operation(oas_fragment):
+    def _wrapper(operation):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"] = operation
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"]
+
+    return _wrapper
+
+
+def test_minimal(convert_operation, oas_fragment):
+    converted = convert_operation(
+        oas_fragment(
+            """
+            responses:
+              '200':
+                description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        responses:
+          '200':
+            description: a response description
+        """
+    )
+
+
+def test_complete(convert_operation, oas_fragment):
+    converted = convert_operation(
+        oas_fragment(
+            """
+            tags:
+              - tag_a
+              - tag_b
+            summary: an operation summary
+            description: an operation description
+            externalDocs: https://docs.example.com/
+            operationId: myOperation
+            produces:
+              - application/json
+            parameters:
+              - in: header
+                name: token
+                type: string
+              - in: path
+                name: username
+                required: true
+                type: string
+              - in: query
+                name: id
+                type: string
+            deprecated: false
+            responses:
+              '200':
+                description: a response description
+                schema:
+                  items:
+                    format: int32
+                    type: integer
+                  type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        tags:
+          - tag_a
+          - tag_b
+        summary: an operation summary
+        description: an operation description
+        externalDocs: https://docs.example.com/
+        operationId: myOperation
+        parameters:
+          - in: header
+            name: token
+            schema:
+              type: string
+          - in: path
+            name: username
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: id
+            schema:
+              type: string
+        deprecated: false
+        responses:
+          '200':
+            content:
+              application/json:
+                schema:
+                  items:
+                    format: int32
+                    type: integer
+                  type: array
+            description: a response description
+        """
+    )
+
+
+def test_request_body(convert_operation, oas_fragment):
+    converted = convert_operation(
+        oas_fragment(
+            """
+            description: an operation description
+            consumes:
+              - application/json
+            parameters:
+              - in: path
+                name: username
+                required: true
+                type: string
+              - in: body
+                name: inventory
+                schema:
+                  type: object
+                  properties:
+                    t-shirt:
+                      type: boolean
+                required: true
+            responses:
+              '200':
+                description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        description: an operation description
+        parameters:
+          - in: path
+            name: username
+            required: true
+            schema:
+              type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  t-shirt:
+                    type: boolean
+          required: true
+        responses:
+          '200':
+             description: a response description
+        """
+    )
+
+
+def test_request_body_formdata(convert_operation, oas_fragment):
+    converted = convert_operation(
+        oas_fragment(
+            """
+            description: an operation description
+            consumes:
+              - application/x-www-form-urlencoded
+            parameters:
+              - in: path
+                name: username
+                required: true
+                type: string
+              - in: formData
+                name: t-shirt
+                type: boolean
+            responses:
+              '200':
+                description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        description: an operation description
+        parameters:
+          - in: path
+            name: username
+            required: true
+            schema:
+              type: string
+        requestBody:
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                type: object
+                properties:
+                  t-shirt:
+                    type: boolean
+        responses:
+          '200':
+             description: a response description
+        """
+    )
+
+
+def test_only_request_body(convert_operation, oas_fragment):
+    converted = convert_operation(
+        oas_fragment(
+            """
+            description: an operation description
+            consumes:
+              - application/json
+            parameters:
+              - in: body
+                name: inventory
+                schema:
+                  type: object
+                  properties:
+                    t-shirt:
+                      type: boolean
+                required: true
+            responses:
+              '200':
+                description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        description: an operation description
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  t-shirt:
+                    type: boolean
+          required: true
+        responses:
+          '200':
+             description: a response description
+        """
+    )
+
+
+def test_vendor_extensions(convert_operation, oas_fragment):
+    converted = convert_operation(
+        oas_fragment(
+            """
+            responses:
+              '200':
+                description: a response description
+            x-vendor-ext: vendor-ext
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        responses:
+          '200':
+            description: a response description
+        x-vendor-ext: vendor-ext
+        """
+    )

--- a/tests/lib2to3/test_convert_parameter.py
+++ b/tests/lib2to3/test_convert_parameter.py
@@ -1,0 +1,427 @@
+""".convert_parameter() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_parameter(oas_fragment):
+    def _wrapper(parameter):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"]["parameters"] = [parameter]
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"]["parameters"][0]
+
+    return _wrapper
+
+
+def test_in_header_complete(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            description: token to be passed as a header
+            in: header
+            items:
+              format: int64
+              type: integer
+            name: token
+            required: true
+            type: array
+            """
+        )
+    )
+    assert converted == oas_fragment(
+        """
+        description: token to be passed as a header
+        in: header
+        name: token
+        required: true
+        schema:
+          items:
+            format: int64
+            type: integer
+          type: array
+        """
+    )
+
+
+def test_in_path_complete(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            description: username to fetch
+            in: path
+            name: username
+            required: true
+            type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        description: username to fetch
+        in: path
+        name: username
+        required: true
+        schema:
+          type: string
+        """
+    )
+
+
+def test_in_query_complete(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            description: ID of the object to fetch
+            in: query
+            items:
+              type: string
+            name: id
+            required: false
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        description: ID of the object to fetch
+        in: query
+        name: id
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        """
+    )
+
+
+def test_in_header_minimal(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            in: header
+            name: token
+            type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: header
+        name: token
+        schema:
+          type: string
+        """
+    )
+
+
+def test_in_path_minimal(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            in: path
+            name: username
+            required: true
+            type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: path
+        name: username
+        required: true
+        schema:
+          type: string
+        """
+    )
+
+
+def test_in_query_minimal(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            in: query
+            name: id
+            type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: query
+        name: id
+        schema:
+          type: string
+        """
+    )
+
+
+def test_collectionFormat_is_csv_path(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: csv
+            in: path
+            items:
+              type: string
+            name: username
+            required: true
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: path
+        name: username
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: simple
+        """
+    )
+
+
+def test_collectionFormat_is_csv_header(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: csv
+            in: header
+            items:
+              type: string
+            name: username
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: header
+        name: username
+        schema:
+          items:
+            type: string
+          type: array
+        style: simple
+        """
+    )
+
+
+def test_collectionFormat_is_csv(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: csv
+            in: query
+            items:
+              type: string
+            name: id
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        explode: false
+        in: query
+        name: id
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+        """
+    )
+
+
+def test_collectionFormat_is_multi(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: multi
+            in: query
+            items:
+              type: string
+            name: id
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        explode: true
+        in: query
+        name: id
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+        """
+    )
+
+
+def test_collectionFormat_is_ssv(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: ssv
+            in: query
+            items:
+              type: string
+            name: id
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: query
+        name: id
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+        """
+    )
+
+
+def test_collectionFormat_is_pipes(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: pipes
+            in: query
+            items:
+              type: string
+            name: id
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: query
+        name: id
+        schema:
+          items:
+            type: string
+          type: array
+        style: pipeDelimited
+        """
+    )
+
+
+def test_collectionFormat_is_tsv(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            collectionFormat: tsv
+            in: query
+            items:
+              type: string
+            name: id
+            type: array
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: query
+        name: id
+        schema:
+          items:
+            type: string
+          type: array
+        """
+    )
+
+
+def test_in_header_vendor_extensions(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            in: header
+            name: token
+            type: string
+            x-vendor-ext: vendor-ext
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: header
+        name: token
+        schema:
+          type: string
+        x-vendor-ext: vendor-ext
+        """
+    )
+
+
+def test_in_path_vendor_extensions(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            in: path
+            name: username
+            required: true
+            type: string
+            x-vendor-ext: vendor-ext
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: path
+        name: username
+        required: true
+        schema:
+          type: string
+        x-vendor-ext: vendor-ext
+        """
+    )
+
+
+def test_in_query_vendor_extensions(convert_parameter, oas_fragment):
+    converted = convert_parameter(
+        oas_fragment(
+            """
+            in: query
+            name: id
+            type: string
+            x-vendor-ext: vendor-ext
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        in: query
+        name: id
+        schema:
+          type: string
+        x-vendor-ext: vendor-ext
+        """
+    )

--- a/tests/lib2to3/test_convert_parameters.py
+++ b/tests/lib2to3/test_convert_parameters.py
@@ -1,0 +1,100 @@
+""".convert_parameters() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+_MISSING = object()
+
+
+@pytest.fixture(scope="function")
+def convert_parameters(oas_fragment):
+    def _wrapper(parameters):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"]["parameters"] = parameters
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"].get("parameters", _MISSING)
+
+    return _wrapper
+
+
+def test_header_path_query(convert_parameters, oas_fragment):
+    converted = convert_parameters(
+        oas_fragment(
+            """
+            - in: header
+              name: token
+              type: string
+            - in: path
+              name: username
+              required: true
+              type: string
+            - in: query
+              name: id
+              type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        - in: header
+          name: token
+          schema:
+            type: string
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: id
+          schema:
+            type: string
+        """
+    )
+
+
+def test_body_is_ignored(convert_parameters, oas_fragment):
+    converted = convert_parameters(
+        oas_fragment(
+            """
+            - description: user to add to the system
+              in: body
+              name: user
+              required: true
+              schema:
+                $ref: '#/definitions/User'
+            """
+        ),
+    )
+    assert converted is _MISSING
+
+
+def test_formData_is_ignored(convert_parameters, oas_fragment):
+    converted = convert_parameters(
+        oas_fragment(
+            """
+            - description: The avatar of the user
+              in: formData
+              name: avatar
+              type: file
+            """
+        ),
+    )
+
+    assert converted is _MISSING

--- a/tests/lib2to3/test_convert_path.py
+++ b/tests/lib2to3/test_convert_path.py
@@ -1,0 +1,230 @@
+""".convert_path() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_path(oas_fragment):
+    def _wrapper(path):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"] = path
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]
+
+    return _wrapper
+
+
+@pytest.mark.parametrize(
+    "method", ["get", "put", "post", "delete", "options", "head", "patch"]
+)
+def test_minimal(convert_path, oas_fragment, method):
+    converted = convert_path(
+        oas_fragment(
+            f"""
+            {method}:
+              responses:
+                '200':
+                  description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        f"""
+        {method}:
+          responses:
+            '200':
+              description: a response description
+        """
+    )
+
+
+def test_complete(convert_path, oas_fragment):
+    converted = convert_path(
+        oas_fragment(
+            """
+            parameters:
+              - in: path
+                name: username
+                required: true
+                type: string
+            get:
+              tags:
+                - tag_a
+                - tag_b
+              summary: an operation summary
+              description: an operation description
+              externalDocs: https://docs.example.com/
+              operationId: myOperation
+              produces:
+                - application/json
+              parameters:
+                - in: header
+                  name: token
+                  type: string
+                - in: query
+                  name: id
+                  type: string
+              responses:
+                '200':
+                  schema:
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
+                  description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        parameters:
+          - in: path
+            name: username
+            schema:
+              type: string
+            required: true
+        get:
+          tags:
+            - tag_a
+            - tag_b
+          summary: an operation summary
+          description: an operation description
+          externalDocs: https://docs.example.com/
+          operationId: myOperation
+          parameters:
+            - in: header
+              name: token
+              schema:
+                type: string
+            - in: query
+              name: id
+              schema:
+                type: string
+          responses:
+            '200':
+              content:
+                application/json:
+                  schema:
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
+              description: a response description
+        """
+    )
+
+
+def test_shared_parameters(convert_path, oas_fragment):
+    converted = convert_path(
+        oas_fragment(
+            """
+            parameters:
+              - in: path
+                name: username
+                required: true
+                type: string
+            get:
+              parameters:
+                - in: header
+                  name: token
+                  type: string
+                - in: query
+                  name: id
+                  type: string
+              responses:
+                '200':
+                  description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        parameters:
+          - in: path
+            name: username
+            schema:
+              type: string
+            required: true
+        get:
+          parameters:
+            - in: header
+              name: token
+              schema:
+                type: string
+            - in: query
+              name: id
+              schema:
+                type: string
+          responses:
+            '200':
+              description: a response description
+        """
+    )
+
+
+def test_multiple(convert_path, oas_fragment):
+    converted = convert_path(
+        oas_fragment(
+            """
+            post:
+              responses:
+                '201':
+                  description: a post response description
+            get:
+              responses:
+                '200':
+                  description: a get response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        post:
+          responses:
+            '201':
+              description: a post response description
+        get:
+          responses:
+            '200':
+              description: a get response description
+        """
+    )
+
+
+def test_vendor_extensions(convert_path, oas_fragment):
+    converted = convert_path(
+        oas_fragment(
+            """
+            get:
+              responses:
+                '200':
+                  description: a response description
+            x-vendor-ext: vendor-ext
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        get:
+          responses:
+            '200':
+              description: a response description
+        x-vendor-ext: vendor-ext
+        """
+    )

--- a/tests/lib2to3/test_convert_paths.py
+++ b/tests/lib2to3/test_convert_paths.py
@@ -1,0 +1,190 @@
+""".convert_paths() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_paths(oas_fragment):
+    def _wrapper(paths):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"] = paths
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]
+
+    return _wrapper
+
+
+def test_minimal(convert_paths, oas_fragment):
+    converted = convert_paths(
+        oas_fragment(
+            """
+            /test:
+              get:
+                responses:
+                  '200':
+                    description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        /test:
+          get:
+            responses:
+              '200':
+                description: a response description
+        """
+    )
+
+
+def test_complete(convert_paths, oas_fragment):
+    pass
+    converted = convert_paths(
+        oas_fragment(
+            """
+            /{username}:
+              parameters:
+                - in: path
+                  name: username
+                  required: true
+                  type: string
+              get:
+                tags:
+                  - tag_a
+                  - tag_b
+                summary: an operation summary
+                description: an operation description
+                externalDocs: https://docs.example.com/
+                operationId: myOperation
+                produces:
+                  - application/json
+                parameters:
+                  - in: header
+                    name: token
+                    type: string
+                  - in: query
+                    name: id
+                    type: string
+                responses:
+                  '200':
+                    schema:
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                    description: a response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        /{username}:
+          parameters:
+            - in: path
+              name: username
+              schema:
+                type: string
+              required: true
+          get:
+            tags:
+              - tag_a
+              - tag_b
+            summary: an operation summary
+            description: an operation description
+            externalDocs: https://docs.example.com/
+            operationId: myOperation
+            parameters:
+              - in: header
+                name: token
+                schema:
+                  type: string
+              - in: query
+                name: id
+                schema:
+                  type: string
+            responses:
+              '200':
+                content:
+                  application/json:
+                    schema:
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                description: a response description
+        """
+    )
+
+
+def test_multiple(convert_paths, oas_fragment):
+    converted = convert_paths(
+        oas_fragment(
+            """
+            /test:
+              get:
+                responses:
+                  '200':
+                    description: a test response description
+            /eggs:
+              post:
+                responses:
+                  '201':
+                    description: an eggs response description
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        /test:
+          get:
+            responses:
+              '200':
+                description: a test response description
+        /eggs:
+          post:
+            responses:
+              '201':
+                description: an eggs response description
+        """
+    )
+
+
+def test_vendor_extensions(convert_paths, oas_fragment):
+    converted = convert_paths(
+        oas_fragment(
+            """
+            /test:
+              get:
+                responses:
+                  '200':
+                    description: a response description
+            x-vendor-ext: vendor-ext
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        /test:
+          get:
+            responses:
+              '200':
+                description: a response description
+        x-vendor-ext: vendor-ext
+        """
+    )

--- a/tests/lib2to3/test_convert_request_body.py
+++ b/tests/lib2to3/test_convert_request_body.py
@@ -1,0 +1,160 @@
+""".convert_request_body() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+_MISSING = object()
+
+
+@pytest.fixture(scope="function")
+def convert_request_body(oas_fragment):
+    def _wrapper(operation_fragment):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"].update(operation_fragment)
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"].get("requestBody", _MISSING)
+
+    return _wrapper
+
+
+def test_minimal(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - application/json
+            parameters:
+              - in: body
+                name: user
+                schema:
+                  $ref: '#/definitions/User'
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/User'
+        """
+    )
+
+
+def test_complete(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - application/json
+            parameters:
+              - description: user to add to the system
+                in: body
+                name: user
+                required: true
+                schema:
+                  $ref: '#/definitions/User'
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/User'
+        description: user to add to the system
+        required: true
+        """
+    )
+
+
+def test_no_consumes(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - in: body
+                name: user
+                schema:
+                  $ref: '#/definitions/User'
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          '*/*':
+            schema:
+              $ref: '#/definitions/User'
+        """
+    )
+
+
+def test_header_path_query_are_ignored(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - in: header
+                name: token
+                type: string
+              - in: path
+                name: username
+                required: true
+                type: string
+              - in: query
+                name: id
+                type: string
+            """
+        ),
+    )
+    assert converted is _MISSING
+
+
+def test_body_and_others(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - in: header
+                name: token
+                type: string
+              - in: path
+                name: username
+                required: true
+                type: string
+              - in: body
+                name: user
+                schema:
+                  $ref: '#/definitions/User'
+              - in: query
+                name: id
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          '*/*':
+            schema:
+              $ref: '#/definitions/User'
+        """
+    )

--- a/tests/lib2to3/test_convert_request_body_formdata.py
+++ b/tests/lib2to3/test_convert_request_body_formdata.py
@@ -1,0 +1,378 @@
+""".convert_request_body() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_request_body(oas_fragment):
+    def _wrapper(operation_fragment):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"].update(operation_fragment)
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"]["requestBody"]
+
+    return _wrapper
+
+
+def test_minimal(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - in: formData
+                name: user
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                user:
+                  type: string
+              type: object
+        """
+    )
+
+
+def test_complete(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+                required: true
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              required: [user]
+        """
+    )
+
+
+def test_complex_schema(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - format: int32
+                in: formData
+                maximum: 100
+                minimum: 5
+                name: age
+                type: integer
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                age:
+                  format: int32
+                  maximum: 100
+                  minimum: 5
+                  type: integer
+              type: object
+        """
+    )
+
+
+def test_consumes_urlencoded(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - application/x-www-form-urlencoded
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+        """
+    )
+
+
+def test_consumes_form_data(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - multipart/form-data
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+        """
+    )
+
+
+def test_consumes_urlencoded_and_form_data(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - application/x-www-form-urlencoded
+              - multipart/form-data
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+          multipart/form-data:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+        """
+    )
+
+
+def test_required(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                required: true
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              required:
+                - user
+              type: object
+        """
+    )
+
+
+def test_multiple(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+              - description: a status of the user
+                in: formData
+                name: status
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                status:
+                  description: a status of the user
+                  type: string
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+        """
+    )
+
+
+def test_type_file_implicit_form_data(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            parameters:
+              - description: a user pic
+                in: formData
+                name: userpic
+                type: file
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                userpic:
+                  description: a user pic
+                  type: file
+              type: object
+        """
+    )
+
+
+def test_type_file_consumes_form_data(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - multipart/form-data
+            parameters:
+              - description: a user pic
+                in: formData
+                name: userpic
+                type: file
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                userpic:
+                  description: a user pic
+                  type: file
+              type: object
+        """
+    )
+
+
+def test_consumes_json_and_urlencoded(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - application/json
+              - application/x-www-form-urlencoded
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+        """
+    )
+
+
+def test_consumes_json_and_form_data(convert_request_body, oas_fragment):
+    converted = convert_request_body(
+        oas_fragment(
+            """
+            consumes:
+              - application/json
+              - multipart/form-data
+            parameters:
+              - description: a name of the user
+                in: formData
+                name: user
+                type: string
+            """
+        ),
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                user:
+                  description: a name of the user
+                  type: string
+              type: object
+        """
+    )

--- a/tests/lib2to3/test_convert_response.py
+++ b/tests/lib2to3/test_convert_response.py
@@ -1,0 +1,417 @@
+""".convert_response() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_response(oas_fragment):
+    def _wrapper(response, produces):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"]["responses"]["200"] = response
+        oas2["paths"]["/test"]["get"]["produces"] = produces
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"]["responses"]["200"]
+
+    return _wrapper
+
+
+def test_minimal(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        """
+    )
+
+
+def test_schema(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+        description: a response description
+        """
+    )
+
+
+def test_schema_mimetypes(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+            """
+        ),
+        produces=["application/json", "text/plain"],
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+          text/plain:
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+        description: a response description
+        """
+    )
+
+
+def test_schema_no_mimetypes(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+            """
+        ),
+        produces=None,
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          '*/*':
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+        description: a response description
+        """
+    )
+
+
+def test_examples(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            examples:
+              application/json:
+                something: important
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            example:
+              something: important
+        description: a response description
+        """
+    )
+
+
+def test_examples_any_type(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            examples:
+              application/json: '{"something": "important"}'
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            example: '{"something": "important"}'
+        description: a response description
+        """
+    )
+
+
+def test_examples_mimetypes(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            examples:
+              application/json:
+                something: important
+              text/plain: something=imporant
+            """
+        ),
+        produces=["application/json", "text/plain"],
+    )
+    assert converted == oas_fragment(
+        """
+        content:
+          application/json:
+            example:
+              something: important
+          text/plain:
+            example: something=imporant
+        description: a response description
+        """
+    )
+
+
+def test_headers_schema_only(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            headers:
+              X-Test:
+                type: string
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        headers:
+          X-Test:
+            schema:
+              type: string
+        """
+    )
+
+
+def test_headers_schema_extra(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            headers:
+              X-Test:
+                description: Is it a test?
+                type: string
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        headers:
+          X-Test:
+            description: Is it a test?
+            schema:
+              type: string
+        """
+    )
+
+
+def test_headers_multiple(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            headers:
+              X-Bar:
+                format: int32
+                type: integer
+              X-Foo:
+                type: string
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        headers:
+          X-Bar:
+            schema:
+              format: int32
+              type: integer
+          X-Foo:
+            schema:
+              type: string
+        """
+    )
+
+
+def test_schema_examples_headers(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            examples:
+              application/json:
+                something: important
+            headers:
+              X-Test:
+                description: Is it a test?
+                type: string
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        content:
+          application/json:
+            example:
+              something: important
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+        headers:
+          X-Test:
+            description: Is it a test?
+            schema:
+              type: string
+        """
+    )
+
+
+def test_complete(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            examples:
+              application/json:
+                something: important
+            headers:
+              X-Test:
+                description: Is it a test?
+                type: string
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        content:
+          application/json:
+            example:
+              something: important
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+        headers:
+          X-Test:
+            description: Is it a test?
+            schema:
+              type: string
+        """
+    )
+
+
+def test_vendor_extensions(convert_response, oas_fragment):
+    converted = convert_response(
+        oas_fragment(
+            """
+            description: a response description
+            examples:
+              application/json:
+                something: important
+            headers:
+              X-Test:
+                description: Is it a test?
+                type: string
+                x-header-ext: header-ext
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+              x-schema-ext: schema-ext
+            x-response-ext: response-ext
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        description: a response description
+        content:
+          application/json:
+            example:
+              something: important
+            schema:
+              items:
+                format: int32
+                type: integer
+              type: array
+              x-schema-ext: schema-ext
+        headers:
+          X-Test:
+            description: Is it a test?
+            schema:
+              type: string
+            x-header-ext: header-ext
+        x-response-ext: response-ext
+        """
+    )

--- a/tests/lib2to3/test_convert_responses.py
+++ b/tests/lib2to3/test_convert_responses.py
@@ -1,0 +1,160 @@
+""".convert_responses() test suite."""
+
+import pytest
+
+import sphinxcontrib.openapi._lib2to3 as lib2to3
+
+
+@pytest.fixture(scope="function")
+def convert_responses(oas_fragment):
+    def _wrapper(responses, produces):
+        oas2 = oas_fragment(
+            """
+            swagger: "2.0"
+            info:
+              title: An example spec
+              version: "1.0"
+            paths:
+              /test:
+                get:
+                  responses:
+                    '200':
+                      description: a response description
+            """
+        )
+        oas2["paths"]["/test"]["get"]["responses"] = responses
+        oas2["paths"]["/test"]["get"]["produces"] = produces
+
+        oas3 = lib2to3.convert(oas2)
+        return oas3["paths"]["/test"]["get"]["responses"]
+
+    return _wrapper
+
+
+def test_minimal(convert_responses, oas_fragment):
+    converted = convert_responses(
+        oas_fragment(
+            """
+            '200':
+              description: a response description
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        '200':
+          description: a response description
+        """
+    )
+
+
+def test_complete(convert_responses, oas_fragment):
+    converted = convert_responses(
+        oas_fragment(
+            """
+            '200':
+              description: a response description
+              examples:
+                application/json:
+                  something: important
+              headers:
+                X-Test:
+                  description: Is it a test?
+                  type: string
+              schema:
+                items:
+                  format: int32
+                  type: integer
+                type: array
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        '200':
+          description: a response description
+          content:
+            application/json:
+              example:
+                something: important
+              schema:
+                items:
+                  format: int32
+                  type: integer
+                type: array
+          headers:
+            X-Test:
+              description: Is it a test?
+              schema:
+                type: string
+        """
+    )
+
+
+def test_multiple(convert_responses, oas_fragment):
+    converted = convert_responses(
+        oas_fragment(
+            """
+            '200':
+              description: OK
+              schema:
+                items:
+                  format: int32
+                  type: integer
+                type: array
+            '400':
+              description: Bad Request
+              headers:
+                X-Test:
+                  description: Is it a test?
+                  type: string
+            default:
+              description: Internal Server Error
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  format: int32
+                  type: integer
+                type: array
+          description: OK
+        '400':
+          description: Bad Request
+          headers:
+            X-Test:
+              description: Is it a test?
+              schema:
+                type: string
+        default:
+          description: Internal Server Error
+        """
+    )
+
+
+def test_vendor_extensions(convert_responses, oas_fragment):
+    converted = convert_responses(
+        oas_fragment(
+            """
+            '200':
+              description: a response description
+            x-vendor-ext: vendor-ext
+            """
+        ),
+        produces=["application/json"],
+    )
+    assert converted == oas_fragment(
+        """
+        '200':
+          description: a response description
+        x-vendor-ext: vendor-ext
+        """
+    )


### PR DESCRIPTION
Our new and shiny OpenAPI renderer supports only OAS 3. Since there are a plenty of OAS 2 users in the wild and we don't converter. This patch only lays down a foundation. Actual usage of the converter will be delivered separately.

- [x] Add `render_request_body`
  - [x] Non form related mimetype in `consumes`
- [x] Add `convert_responses`
- [x] Add `convert_response`
  - [x] Ensure descriminator is properly converted
  - [x] Ensure xml-something is properly converted
- [x] Add `convert_operation`
- [x] Add `convert_paths`
- [x] Vendor extensions must be copied over (if possible)
- [x] Implement missing tests in `test_convert.py` (see stubs).
- [x] Add test that ensures that there's no `parameters` in the output spec if after conversion the only OAS 2 body parameter has been converted into `requestBody`.