### PR TITLE
Use OAS YAML fragments in renderers tests

### DIFF
--- a/tests/renderers/httpdomain/conftest.py
+++ b/tests/renderers/httpdomain/conftest.py
@@ -1,6 +1,9 @@
 """Some shared goodies."""
 
+import textwrap
+
 import pytest
+import yaml
 
 from sphinxcontrib.openapi import renderers
 
@@ -13,3 +16,11 @@ def fakestate():
 @pytest.fixture(scope="function")
 def testrenderer(fakestate):
     return renderers.HttpdomainRenderer(fakestate, {})
+
+
+@pytest.fixture(scope="function")
+def oas_fragment():
+    def oas_fragment(fragment):
+        return yaml.safe_load(textwrap.dedent(fragment))
+
+    return oas_fragment

--- a/tests/renderers/httpdomain/test_render_operation.py
+++ b/tests/renderers/httpdomain/test_render_operation.py
@@ -11,36 +11,36 @@ def textify(generator):
     return "\n".join(generator)
 
 
-def test_render_operation(testrenderer):
+def test_render_operation(testrenderer, oas_fragment):
     """Usual operation definition is rendered."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences/{evidenceId}",
             "get",
-            {
-                "summary": "Retrieve an evidence by ID.",
-                "description": "More verbose description...",
-                "parameters": [
-                    {
-                        "name": "evidenceId",
-                        "in": "path",
-                        "required": True,
-                        "description": "A unique evidence identifier to query.",
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "name": "details",
-                        "in": "query",
-                        "description": "If true, information w/ details is returned.",
-                        "schema": {"type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {"description": "An evidence."},
-                    "404": {"description": "An evidence not found."},
-                },
-            },
+            oas_fragment(
+                """
+                summary: Retrieve an evidence by ID.
+                description: More verbose description...
+                parameters:
+                  - name: evidenceId
+                    in: path
+                    required: true
+                    description: A unique evidence identifier to query.
+                    schema:
+                      type: string
+                  - name: details
+                    in: query
+                    description: If true, information w/ details is returned.
+                    schema:
+                      type: boolean
+                responses:
+                  '200':
+                    description: An evidence.
+                  '404':
+                    description: An evidence not found.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -65,14 +65,20 @@ def test_render_operation(testrenderer):
     )
 
 
-def test_render_operation_minimal(testrenderer):
+def test_render_operation_minimal(testrenderer, oas_fragment):
     """Operation minimal definition is rendered."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {"responses": {"201": {"description": "An evidence created."}}},
+            oas_fragment(
+                """
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -85,17 +91,21 @@ def test_render_operation_minimal(testrenderer):
     )
 
 
-def test_render_operation_summary(testrenderer):
+def test_render_operation_summary(testrenderer, oas_fragment):
     """Operation's 'summary' is rendered in bold."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "summary": "Create an evidence.",
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                summary: Create an evidence.
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -110,17 +120,21 @@ def test_render_operation_summary(testrenderer):
     )
 
 
-def test_render_operation_description(testrenderer):
+def test_render_operation_description(testrenderer, oas_fragment):
     """Operation's 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "description": "Create an evidence.",
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                description: Create an evidence.
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -135,17 +149,23 @@ def test_render_operation_description(testrenderer):
     )
 
 
-def test_render_operation_description_multiline(testrenderer):
+def test_render_operation_description_multiline(testrenderer, oas_fragment):
     """Operation's multiline 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "description": "Create\nan evidence.",
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                description: |
+                  Create
+                  an evidence.
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -161,17 +181,21 @@ def test_render_operation_description_multiline(testrenderer):
     )
 
 
-def test_render_operation_description_commonmark_default(testrenderer):
+def test_render_operation_description_commonmark_default(testrenderer, oas_fragment):
     """Operation's 'description' must be in commonmark by default."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "description": "__Create__ an `evidence`.",
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                description: __Create__ an `evidence`.
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -186,7 +210,7 @@ def test_render_operation_description_commonmark_default(testrenderer):
     )
 
 
-def test_render_operation_description_commonmark(fakestate):
+def test_render_operation_description_commonmark(fakestate, oas_fragment):
     """Operation's 'description' can be in commonmark."""
 
     testrenderer = renderers.HttpdomainRenderer(fakestate, {"markup": "commonmark"})
@@ -194,10 +218,14 @@ def test_render_operation_description_commonmark(fakestate):
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "description": "__Create__ an `evidence`.",
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                description: __Create__ an `evidence`.
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -212,7 +240,9 @@ def test_render_operation_description_commonmark(fakestate):
     )
 
 
-def test_render_operation_description_commonmark_restructuredtext(fakestate):
+def test_render_operation_description_commonmark_restructuredtext(
+    fakestate, oas_fragment
+):
     """Operation's 'description' can be in restructuredtext."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -222,10 +252,14 @@ def test_render_operation_description_commonmark_restructuredtext(fakestate):
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "description": "__Create__ an `evidence`.",
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                description: __Create__ an `evidence`.
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -240,17 +274,21 @@ def test_render_operation_description_commonmark_restructuredtext(fakestate):
     )
 
 
-def test_render_operation_deprecated(testrenderer):
+def test_render_operation_deprecated(testrenderer, oas_fragment):
     """Operation's 'deprecated' mark is rendered."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "deprecated": True,
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                responses:
+                  '201':
+                    description: An evidence created.
+                deprecated: true
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -264,21 +302,26 @@ def test_render_operation_deprecated(testrenderer):
     )
 
 
-def test_render_operation_w_requestbody(testrenderer):
+def test_render_operation_w_requestbody(testrenderer, oas_fragment):
     """Operation's 'requestBody' is rendered."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             "post",
-            {
-                "requestBody": {
-                    "content": {
-                        "application/json": {"example": {"foo": "bar", "baz": 42}}
-                    },
-                },
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                requestBody:
+                  content:
+                    application/json:
+                      example:
+                        foo: bar
+                        baz: 42
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(
@@ -304,21 +347,26 @@ def test_render_operation_w_requestbody(testrenderer):
 @pytest.mark.parametrize(
     ["method"], [pytest.param("POST"), pytest.param("pOst"), pytest.param("post")]
 )
-def test_render_operation_caseinsensitive_method(testrenderer, method):
+def test_render_operation_caseinsensitive_method(testrenderer, method, oas_fragment):
     """Operation's 'method' is case insensitive."""
 
     markup = textify(
         testrenderer.render_operation(
             "/evidences",
             method,
-            {
-                "requestBody": {
-                    "content": {
-                        "application/json": {"example": {"foo": "bar", "baz": 42}}
-                    },
-                },
-                "responses": {"201": {"description": "An evidence created."}},
-            },
+            oas_fragment(
+                """
+                requestBody:
+                  content:
+                    application/json:
+                      example:
+                        foo: bar
+                        baz: 42
+                responses:
+                  '201':
+                    description: An evidence created.
+                """
+            ),
         )
     )
     assert markup == textwrap.dedent(

--- a/tests/renderers/httpdomain/test_render_parameter.py
+++ b/tests/renderers/httpdomain/test_render_parameter.py
@@ -9,18 +9,21 @@ def textify(generator):
     return "\n".join(generator)
 
 
-def test_render_parameter_path(testrenderer):
+def test_render_parameter_path(testrenderer, oas_fragment):
     """Usual path parameter's definition is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "required": True,
-                "description": "A unique evidence identifier to query.",
-                "schema": {"type": "string"},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                description: A unique evidence identifier to query.
+                schema:
+                  type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -32,12 +35,18 @@ def test_render_parameter_path(testrenderer):
     )
 
 
-def test_render_parameter_path_minimal(testrenderer):
+def test_render_parameter_path_minimal(testrenderer, oas_fragment):
     """Path parameter's minimal definition is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "path", "required": True}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -48,17 +57,19 @@ def test_render_parameter_path_minimal(testrenderer):
     )
 
 
-def test_render_parameter_path_description(testrenderer):
+def test_render_parameter_path_description(testrenderer, oas_fragment):
     """Path parameter's 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "required": True,
-                "description": "A unique evidence identifier to query.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                description: A unique evidence identifier to query.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -70,17 +81,21 @@ def test_render_parameter_path_description(testrenderer):
     )
 
 
-def test_render_parameter_path_multiline_description(testrenderer):
+def test_render_parameter_path_multiline_description(testrenderer, oas_fragment):
     """Path parameter's multiline 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "required": True,
-                "description": "A unique evidence\nidentifier to query.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                description: |
+                  A unique evidence
+                  identifier to query.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -93,17 +108,23 @@ def test_render_parameter_path_multiline_description(testrenderer):
     )
 
 
-def test_render_parameter_path_description_commonmark_default(testrenderer):
+def test_render_parameter_path_description_commonmark_default(
+    testrenderer, oas_fragment
+):
     """Path parameter's 'description' must be in commonmark by default."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "required": True,
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -116,18 +137,22 @@ def test_render_parameter_path_description_commonmark_default(testrenderer):
     )
 
 
-def test_render_parameter_path_description_commonmark(fakestate):
+def test_render_parameter_path_description_commonmark(fakestate, oas_fragment):
     """Path parameter's 'description' can be in commonmark."""
 
     testrenderer = renderers.HttpdomainRenderer(fakestate, {"markup": "commonmark"})
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "required": True,
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -140,7 +165,7 @@ def test_render_parameter_path_description_commonmark(fakestate):
     )
 
 
-def test_render_parameter_path_description_restructuredtext(fakestate):
+def test_render_parameter_path_description_restructuredtext(fakestate, oas_fragment):
     """Path parameter's 'description' can be in restructuredtext."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -148,12 +173,16 @@ def test_render_parameter_path_description_restructuredtext(fakestate):
     )
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "required": True,
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -166,12 +195,19 @@ def test_render_parameter_path_description_restructuredtext(fakestate):
     )
 
 
-def test_render_parameter_path_deprecated(testrenderer):
+def test_render_parameter_path_deprecated(testrenderer, oas_fragment):
     """Path parameter's 'deprecated' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "path", "required": True, "deprecated": True}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                deprecated: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -182,12 +218,19 @@ def test_render_parameter_path_deprecated(testrenderer):
     )
 
 
-def test_render_parameter_path_deprecated_false(testrenderer):
+def test_render_parameter_path_deprecated_false(testrenderer, oas_fragment):
     """Path parameter's 'deprecated' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "path", "required": True, "deprecated": False}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                required: true
+                deprecated: false
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -198,12 +241,19 @@ def test_render_parameter_path_deprecated_false(testrenderer):
     )
 
 
-def test_render_parameter_path_type(testrenderer):
+def test_render_parameter_path_type(testrenderer, oas_fragment):
     """Path parameter's type is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "path", "schema": {"type": "string"}}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                schema:
+                  type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -214,16 +264,20 @@ def test_render_parameter_path_type(testrenderer):
     )
 
 
-def test_render_parameter_path_type_with_format(testrenderer):
+def test_render_parameter_path_type_with_format(testrenderer, oas_fragment):
     """Path parameter's type with format is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "schema": {"type": "string", "format": "uuid4"},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                schema:
+                  type: string
+                  format: uuid4
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -234,16 +288,21 @@ def test_render_parameter_path_type_with_format(testrenderer):
     )
 
 
-def test_render_parameter_path_type_from_content(testrenderer):
+def test_render_parameter_path_type_from_content(testrenderer, oas_fragment):
     """Path parameter's type from content is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "content": {"text/plain": {"schema": {"type": "string"}}},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                content:
+                  text/plain:
+                    schema:
+                      type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -254,17 +313,20 @@ def test_render_parameter_path_type_from_content(testrenderer):
     )
 
 
-def test_render_parameter_query(testrenderer):
+def test_render_parameter_query(testrenderer, oas_fragment):
     """Usual query parameter's definition is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "path",
-                "description": "A unique evidence identifier to query.",
-                "schema": {"type": "string"},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                description: A unique evidence identifier to query.
+                schema:
+                  type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -276,11 +338,18 @@ def test_render_parameter_query(testrenderer):
     )
 
 
-def test_render_parameter_query_minimal(testrenderer):
+def test_render_parameter_query_minimal(testrenderer, oas_fragment):
     """Query parameter's minimal definition is rendered."""
 
     markup = textify(
-        testrenderer.render_parameter({"name": "evidenceId", "in": "path"})
+        testrenderer.render_parameter(
+            oas_fragment(
+                """
+                name: evidenceId
+                in: path
+                """
+            )
+        )
     )
     assert markup == textwrap.dedent(
         """\
@@ -289,16 +358,18 @@ def test_render_parameter_query_minimal(testrenderer):
     )
 
 
-def test_render_parameter_query_description(testrenderer):
+def test_render_parameter_query_description(testrenderer, oas_fragment):
     """Query parameter's 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "description": "A unique evidence identifier to query.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                description: A unique evidence identifier to query.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -309,16 +380,20 @@ def test_render_parameter_query_description(testrenderer):
     )
 
 
-def test_render_parameter_query_multiline_description(testrenderer):
+def test_render_parameter_query_multiline_description(testrenderer, oas_fragment):
     """Query parameter's multiline 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "description": "A unique evidence\nidentifier to query.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                description: |
+                  A unique evidence
+                  identifier to query.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -330,16 +405,22 @@ def test_render_parameter_query_multiline_description(testrenderer):
     )
 
 
-def test_render_parameter_query_description_commonmark_default(testrenderer):
+def test_render_parameter_query_description_commonmark_default(
+    testrenderer, oas_fragment
+):
     """Query parameter's 'description' must be in commonmark by default."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -351,17 +432,21 @@ def test_render_parameter_query_description_commonmark_default(testrenderer):
     )
 
 
-def test_render_parameter_query_description_commonmark(fakestate):
+def test_render_parameter_query_description_commonmark(fakestate, oas_fragment):
     """Query parameter's 'description' can be in commonmark."""
 
     testrenderer = renderers.HttpdomainRenderer(fakestate, {"markup": "commonmark"})
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -373,7 +458,7 @@ def test_render_parameter_query_description_commonmark(fakestate):
     )
 
 
-def test_render_parameter_query_description_restructuredtext(fakestate):
+def test_render_parameter_query_description_restructuredtext(fakestate, oas_fragment):
     """Query parameter's 'description' can be in restructuredtext."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -381,11 +466,15 @@ def test_render_parameter_query_description_restructuredtext(fakestate):
     )
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -397,12 +486,18 @@ def test_render_parameter_query_description_restructuredtext(fakestate):
     )
 
 
-def test_render_parameter_query_required(testrenderer):
+def test_render_parameter_query_required(testrenderer, oas_fragment):
     """Query parameter's 'required' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "query", "required": True}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                required: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -413,12 +508,18 @@ def test_render_parameter_query_required(testrenderer):
     )
 
 
-def test_render_parameter_query_required_false(testrenderer):
+def test_render_parameter_query_required_false(testrenderer, oas_fragment):
     """Query parameter's 'required' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "query", "required": False}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                required: false
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -428,12 +529,18 @@ def test_render_parameter_query_required_false(testrenderer):
     )
 
 
-def test_render_parameter_query_deprecated(testrenderer):
+def test_render_parameter_query_deprecated(testrenderer, oas_fragment):
     """Query parameter's 'deprecated' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "query", "deprecated": True}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                deprecated: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -444,12 +551,18 @@ def test_render_parameter_query_deprecated(testrenderer):
     )
 
 
-def test_render_parameter_query_deprecated_false(testrenderer):
+def test_render_parameter_query_deprecated_false(testrenderer, oas_fragment):
     """Query parameter's 'deprecated' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "query", "deprecated": False}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                deprecated: false
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -459,12 +572,19 @@ def test_render_parameter_query_deprecated_false(testrenderer):
     )
 
 
-def test_render_parameter_query_required_deprecated(testrenderer):
+def test_render_parameter_query_required_deprecated(testrenderer, oas_fragment):
     """Both query parameter's markers are rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "query", "required": True, "deprecated": True}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                required: true
+                deprecated: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -475,12 +595,19 @@ def test_render_parameter_query_required_deprecated(testrenderer):
     )
 
 
-def test_render_parameter_query_type(testrenderer):
+def test_render_parameter_query_type(testrenderer, oas_fragment):
     """Query parameter's type is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "query", "schema": {"type": "string"}}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                schema:
+                  type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -491,16 +618,20 @@ def test_render_parameter_query_type(testrenderer):
     )
 
 
-def test_render_parameter_query_type_with_format(testrenderer):
+def test_render_parameter_query_type_with_format(testrenderer, oas_fragment):
     """Query parameter's type with format is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "schema": {"type": "string", "format": "uuid4"},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                schema:
+                  type: string
+                  format: uuid4
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -511,16 +642,21 @@ def test_render_parameter_query_type_with_format(testrenderer):
     )
 
 
-def test_render_parameter_query_type_from_content(testrenderer):
+def test_render_parameter_query_type_from_content(testrenderer, oas_fragment):
     """Query parameter's type from content is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "query",
-                "content": {"text/plain": {"schema": {"type": "string"}}},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: query
+                content:
+                  text/plain:
+                    schema:
+                      type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -531,17 +667,20 @@ def test_render_parameter_query_type_from_content(testrenderer):
     )
 
 
-def test_render_parameter_header(testrenderer):
+def test_render_parameter_header(testrenderer, oas_fragment):
     """Usual header parameter's definition is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "X-Request-Id",
-                "in": "header",
-                "description": "A unique request identifier.",
-                "schema": {"type": "string"},
-            }
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                description: A unique request identifier.
+                schema:
+                  type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -553,11 +692,18 @@ def test_render_parameter_header(testrenderer):
     )
 
 
-def test_render_parameter_header_minimal(testrenderer):
+def test_render_parameter_header_minimal(testrenderer, oas_fragment):
     """Header parameter's minimal definition is rendered."""
 
     markup = textify(
-        testrenderer.render_parameter({"name": "X-Request-Id", "in": "header"})
+        testrenderer.render_parameter(
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                """
+            )
+        )
     )
     assert markup == textwrap.dedent(
         """\
@@ -566,16 +712,18 @@ def test_render_parameter_header_minimal(testrenderer):
     )
 
 
-def test_render_parameter_header_description(testrenderer):
+def test_render_parameter_header_description(testrenderer, oas_fragment):
     """Header parameter's 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "X-Request-Id",
-                "in": "header",
-                "description": "A unique request identifier.",
-            }
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                description: A unique request identifier.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -586,16 +734,20 @@ def test_render_parameter_header_description(testrenderer):
     )
 
 
-def test_render_parameter_header_multiline_description(testrenderer):
+def test_render_parameter_header_multiline_description(testrenderer, oas_fragment):
     """Header parameter's multiline 'description' is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "X-Request-Id",
-                "in": "header",
-                "description": "A unique request\nidentifier.",
-            }
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                description: |
+                  A unique request
+                  identifier.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -607,16 +759,22 @@ def test_render_parameter_header_multiline_description(testrenderer):
     )
 
 
-def test_render_parameter_header_description_commonmark_default(testrenderer):
+def test_render_parameter_header_description_commonmark_default(
+    testrenderer, oas_fragment
+):
     """Header parameter's 'description' must be in commonmark by default."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "header",
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: header
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -628,17 +786,21 @@ def test_render_parameter_header_description_commonmark_default(testrenderer):
     )
 
 
-def test_render_parameter_header_description_commonmark(fakestate):
+def test_render_parameter_header_description_commonmark(fakestate, oas_fragment):
     """Header parameter's 'description' can be in commonmark."""
 
     testrenderer = renderers.HttpdomainRenderer(fakestate, {"markup": "commonmark"})
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "header",
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: header
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -650,7 +812,7 @@ def test_render_parameter_header_description_commonmark(fakestate):
     )
 
 
-def test_render_parameter_header_description_restructuredtext(fakestate):
+def test_render_parameter_header_description_restructuredtext(fakestate, oas_fragment):
     """Header parameter's 'description' can be in restructuredtext."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -658,11 +820,15 @@ def test_render_parameter_header_description_restructuredtext(fakestate):
     )
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "header",
-                "description": "A unique evidence `identifier`\nto __query__.",
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: header
+                description: |
+                  A unique evidence `identifier`
+                  to __query__.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -674,12 +840,18 @@ def test_render_parameter_header_description_restructuredtext(fakestate):
     )
 
 
-def test_render_parameter_header_required(testrenderer):
+def test_render_parameter_header_required(testrenderer, oas_fragment):
     """Header parameter's 'required' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "X-Request-Id", "in": "header", "required": True}
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                required: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -690,12 +862,18 @@ def test_render_parameter_header_required(testrenderer):
     )
 
 
-def test_render_parameter_header_required_false(testrenderer):
+def test_render_parameter_header_required_false(testrenderer, oas_fragment):
     """Header parameter's 'required' marker is not rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "X-Request-Id", "in": "header", "required": False}
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                required: false
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -705,12 +883,18 @@ def test_render_parameter_header_required_false(testrenderer):
     )
 
 
-def test_render_parameter_header_deprecated(testrenderer):
+def test_render_parameter_header_deprecated(testrenderer, oas_fragment):
     """Header parameter's 'deprecated' marker is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "X-Request-Id", "in": "header", "deprecated": True}
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                deprecated: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -721,12 +905,18 @@ def test_render_parameter_header_deprecated(testrenderer):
     )
 
 
-def test_render_parameter_header_deprecated_false(testrenderer):
+def test_render_parameter_header_deprecated_false(testrenderer, oas_fragment):
     """Header parameter's 'deprecated' marker is not rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "X-Request-Id", "in": "header", "deprecated": False}
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                deprecated: false
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -736,17 +926,19 @@ def test_render_parameter_header_deprecated_false(testrenderer):
     )
 
 
-def test_render_parameter_header_required_deprecated(testrenderer):
+def test_render_parameter_header_required_deprecated(testrenderer, oas_fragment):
     """Both header parameter's markers are rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "X-Request-Id",
-                "in": "header",
-                "required": True,
-                "deprecated": True,
-            }
+            oas_fragment(
+                """
+                name: X-Request-Id
+                in: header
+                required: true
+                deprecated: true
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -757,12 +949,19 @@ def test_render_parameter_header_required_deprecated(testrenderer):
     )
 
 
-def test_render_parameter_header_type(testrenderer):
+def test_render_parameter_header_type(testrenderer, oas_fragment):
     """Header parameter's type is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {"name": "evidenceId", "in": "header", "schema": {"type": "string"}}
+            oas_fragment(
+                """
+                name: evidenceId
+                in: header
+                schema:
+                  type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -773,16 +972,20 @@ def test_render_parameter_header_type(testrenderer):
     )
 
 
-def test_render_parameter_header_type_with_format(testrenderer):
+def test_render_parameter_header_type_with_format(testrenderer, oas_fragment):
     """Header parameter's type with format is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "header",
-                "schema": {"type": "string", "format": "uuid4"},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: header
+                schema:
+                  type: string
+                  format: uuid4
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -793,16 +996,21 @@ def test_render_parameter_header_type_with_format(testrenderer):
     )
 
 
-def test_render_parameter_header_type_from_content(testrenderer):
+def test_render_parameter_header_type_from_content(testrenderer, oas_fragment):
     """Header parameter's type from content is rendered."""
 
     markup = textify(
         testrenderer.render_parameter(
-            {
-                "name": "evidenceId",
-                "in": "header",
-                "content": {"text/plain": {"schema": {"type": "string"}}},
-            }
+            oas_fragment(
+                """
+                name: evidenceId
+                in: header
+                content:
+                  text/plain:
+                    schema:
+                      type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(

--- a/tests/renderers/httpdomain/test_render_parameters.py
+++ b/tests/renderers/httpdomain/test_render_parameters.py
@@ -12,27 +12,36 @@ def textify(generator):
     return "\n".join(generator)
 
 
-def test_render_parameters_no_items(testrenderer):
+def test_render_parameters_no_items(testrenderer, oas_fragment):
     """No parameter definitions are rendered."""
 
-    markup = textify(testrenderer.render_parameters([]))
+    markup = textify(
+        testrenderer.render_parameters(
+            oas_fragment(
+                """
+                []
+                """
+            )
+        )
+    )
     assert markup == ""
 
 
-def test_render_parameters_one_item(testrenderer):
+def test_render_parameters_one_item(testrenderer, oas_fragment):
     """One usual parameter definition is rendered."""
 
     markup = textify(
         testrenderer.render_parameters(
-            [
-                {
-                    "name": "evidenceId",
-                    "in": "path",
-                    "required": True,
-                    "description": "A unique evidence identifier to query.",
-                    "schema": {"type": "string"},
-                }
-            ]
+            oas_fragment(
+                """
+                - name: evidenceId
+                  in: path
+                  required: true
+                  description: A unique evidence identifier to query.
+                  schema:
+                    type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -44,33 +53,32 @@ def test_render_parameters_one_item(testrenderer):
     )
 
 
-def test_render_parameters_many_items(testrenderer):
+def test_render_parameters_many_items(testrenderer, oas_fragment):
     """Many parameter definitions are rendered."""
 
     markup = textify(
         testrenderer.render_parameters(
-            [
-                {
-                    "name": "evidenceId",
-                    "in": "path",
-                    "required": True,
-                    "description": "A unique evidence identifier to query.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "details",
-                    "in": "query",
-                    "description": "If true, information w/ details is returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "Api-Version",
-                    "in": "header",
-                    "default": "1",
-                    "description": "API version to use for the request.",
-                    "schema": {"type": "integer"},
-                },
-            ]
+            oas_fragment(
+                """
+                - name: evidenceId
+                  in: path
+                  required: true
+                  description: A unique evidence identifier to query.
+                  schema:
+                    type: string
+                - name: details
+                  in: query
+                  description: If true, information w/ details is returned.
+                  schema:
+                    type: boolean
+                - name: Api-Version
+                  in: header
+                  default: '1'
+                  description: API version to use for the request.
+                  schema:
+                    type: integer
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -89,32 +97,33 @@ def test_render_parameters_many_items(testrenderer):
 
 
 @pytest.mark.parametrize("permutation_seq", itertools.permutations(range(3)))
-def test_render_parameters_many_items_ordered(testrenderer, permutation_seq):
+def test_render_parameters_many_items_ordered(
+    testrenderer, oas_fragment, permutation_seq
+):
     """Many parameter definitions are rendered and properly ordered."""
 
-    parameters = [
-        {
-            "name": "evidenceId",
-            "in": "path",
-            "required": True,
-            "description": "A unique evidence identifier to query.",
-            "schema": {"type": "string"},
-        },
-        {
-            "name": "details",
-            "in": "query",
-            "description": "If true, information w/ details is returned.",
-            "schema": {"type": "boolean"},
-        },
-        {
-            "name": "Api-Version",
-            "in": "header",
-            "required": False,
-            "default": "1",
-            "description": "API version to use for the request.",
-            "schema": {"type": "integer"},
-        },
-    ]
+    parameters = oas_fragment(
+        """
+        - name: evidenceId
+          in: path
+          required: true
+          description: A unique evidence identifier to query.
+          schema:
+            type: string
+        - name: details
+          in: query
+          description: If true, information w/ details is returned.
+          schema:
+            type: boolean
+        - name: Api-Version
+          in: header
+          required: false
+          default: '1'
+          description: API version to use for the request.
+          schema:
+            type: integer
+        """
+    )
 
     markup = textify(
         testrenderer.render_parameters(
@@ -140,53 +149,49 @@ def test_render_parameters_many_items_ordered(testrenderer, permutation_seq):
     )
 
 
-def test_render_parameters_many_items_stable_order(testrenderer):
+def test_render_parameters_many_items_stable_order(testrenderer, oas_fragment):
     """Many parameter definitions are rendered w/ preserved order."""
 
     markup = textify(
         testrenderer.render_parameters(
-            [
-                {
-                    "name": "kind",
-                    "in": "path",
-                    "required": True,
-                    "description": "An evidence kind.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "Api-Version",
-                    "in": "header",
-                    "default": "1",
-                    "description": "API version to use for the request.",
-                    "schema": {"type": "integer"},
-                },
-                {
-                    "name": "details",
-                    "in": "query",
-                    "description": "If true, information w/ details is returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "evidenceId",
-                    "in": "path",
-                    "required": True,
-                    "description": "A unique evidence identifier to query.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "related",
-                    "in": "query",
-                    "description": "If true, links to related evidences are returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "Accept",
-                    "in": "header",
-                    "default": "application/json",
-                    "description": "A desired Content-Type of HTTP response.",
-                    "schema": {"type": "string"},
-                },
-            ]
+            oas_fragment(
+                """
+                - name: kind
+                  in: path
+                  required: true
+                  description: An evidence kind.
+                  schema:
+                    type: string
+                - name: Api-Version
+                  in: header
+                  default: '1'
+                  description: API version to use for the request.
+                  schema:
+                    type: integer
+                - name: details
+                  in: query
+                  description: If true, information w/ details is returned.
+                  schema:
+                    type: boolean
+                - name: evidenceId
+                  in: path
+                  required: true
+                  description: A unique evidence identifier to query.
+                  schema:
+                    type: string
+                - name: related
+                  in: query
+                  description: If true, links to related evidences are returned.
+                  schema:
+                    type: boolean
+                - name: Accept
+                  in: header
+                  default: application/json
+                  description: A desired Content-Type of HTTP response.
+                  schema:
+                    type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -213,7 +218,7 @@ def test_render_parameters_many_items_stable_order(testrenderer):
     )
 
 
-def test_render_parameters_custom_order(fakestate):
+def test_render_parameters_custom_order(fakestate, oas_fragment):
     """Many parameter definitions are rendered w/ preserved order."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -222,48 +227,44 @@ def test_render_parameters_custom_order(fakestate):
 
     markup = textify(
         testrenderer.render_parameters(
-            [
-                {
-                    "name": "kind",
-                    "in": "path",
-                    "required": True,
-                    "description": "An evidence kind.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "Api-Version",
-                    "in": "header",
-                    "default": "1",
-                    "description": "API version to use for the request.",
-                    "schema": {"type": "integer"},
-                },
-                {
-                    "name": "details",
-                    "in": "query",
-                    "description": "If true, information w/ details is returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "evidenceId",
-                    "in": "path",
-                    "required": True,
-                    "description": "A unique evidence identifier to query.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "related",
-                    "in": "query",
-                    "description": "If true, links to related evidences are returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "Accept",
-                    "in": "header",
-                    "default": "application/json",
-                    "description": "A desired Content-Type of HTTP response.",
-                    "schema": {"type": "string"},
-                },
-            ]
+            oas_fragment(
+                """
+                - name: kind
+                  in: path
+                  required: true
+                  description: An evidence kind.
+                  schema:
+                    type: string
+                - name: Api-Version
+                  in: header
+                  default: '1'
+                  description: API version to use for the request.
+                  schema:
+                    type: integer
+                - name: details
+                  in: query
+                  description: If true, information w/ details is returned.
+                  schema:
+                    type: boolean
+                - name: evidenceId
+                  in: path
+                  required: true
+                  description: A unique evidence identifier to query.
+                  schema:
+                    type: string
+                - name: related
+                  in: query
+                  description: If true, links to related evidences are returned.
+                  schema:
+                    type: boolean
+                - name: Accept
+                  in: header
+                  default: application/json
+                  description: A desired Content-Type of HTTP response.
+                  schema:
+                    type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -290,7 +291,7 @@ def test_render_parameters_custom_order(fakestate):
     )
 
 
-def test_render_parameters_custom_order_partial(fakestate):
+def test_render_parameters_custom_order_partial(fakestate, oas_fragment):
     """Many parameter definitions are rendered w/ preserved order."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -299,48 +300,44 @@ def test_render_parameters_custom_order_partial(fakestate):
 
     markup = textify(
         testrenderer.render_parameters(
-            [
-                {
-                    "name": "kind",
-                    "in": "path",
-                    "required": True,
-                    "description": "An evidence kind.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "Api-Version",
-                    "in": "header",
-                    "default": "1",
-                    "description": "API version to use for the request.",
-                    "schema": {"type": "integer"},
-                },
-                {
-                    "name": "details",
-                    "in": "query",
-                    "description": "If true, information w/ details is returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "evidenceId",
-                    "in": "path",
-                    "required": True,
-                    "description": "A unique evidence identifier to query.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "related",
-                    "in": "query",
-                    "description": "If true, links to related evidences are returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "Accept",
-                    "in": "header",
-                    "default": "application/json",
-                    "description": "A desired Content-Type of HTTP response.",
-                    "schema": {"type": "string"},
-                },
-            ]
+            oas_fragment(
+                """
+                - name: kind
+                  in: path
+                  required: true
+                  description: An evidence kind.
+                  schema:
+                    type: string
+                - name: Api-Version
+                  in: header
+                  default: '1'
+                  description: API version to use for the request.
+                  schema:
+                    type: integer
+                - name: details
+                  in: query
+                  description: If true, information w/ details is returned.
+                  schema:
+                    type: boolean
+                - name: evidenceId
+                  in: path
+                  required: true
+                  description: A unique evidence identifier to query.
+                  schema:
+                    type: string
+                - name: related
+                  in: query
+                  description: If true, links to related evidences are returned.
+                  schema:
+                    type: boolean
+                - name: Accept
+                  in: header
+                  default: application/json
+                  description: A desired Content-Type of HTTP response.
+                  schema:
+                    type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -367,7 +364,7 @@ def test_render_parameters_custom_order_partial(fakestate):
     )
 
 
-def test_render_parameters_case_insensitive(fakestate):
+def test_render_parameters_case_insensitive(fakestate, oas_fragment):
     """Many parameter definitions are rendered w/ preserved order."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -376,48 +373,44 @@ def test_render_parameters_case_insensitive(fakestate):
 
     markup = textify(
         testrenderer.render_parameters(
-            [
-                {
-                    "name": "kind",
-                    "in": "PATH",
-                    "required": True,
-                    "description": "An evidence kind.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "Api-Version",
-                    "in": "header",
-                    "default": "1",
-                    "description": "API version to use for the request.",
-                    "schema": {"type": "integer"},
-                },
-                {
-                    "name": "details",
-                    "in": "query",
-                    "description": "If true, information w/ details is returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "evidenceId",
-                    "in": "Path",
-                    "required": True,
-                    "description": "A unique evidence identifier to query.",
-                    "schema": {"type": "string"},
-                },
-                {
-                    "name": "related",
-                    "in": "qUery",
-                    "description": "If true, links to related evidences are returned.",
-                    "schema": {"type": "boolean"},
-                },
-                {
-                    "name": "Accept",
-                    "in": "headeR",
-                    "default": "application/json",
-                    "description": "A desired Content-Type of HTTP response.",
-                    "schema": {"type": "string"},
-                },
-            ]
+            oas_fragment(
+                """
+                - name: kind
+                  in: PATH
+                  required: true
+                  description: An evidence kind.
+                  schema:
+                    type: string
+                - name: Api-Version
+                  in: header
+                  default: '1'
+                  description: API version to use for the request.
+                  schema:
+                    type: integer
+                - name: details
+                  in: query
+                  description: If true, information w/ details is returned.
+                  schema:
+                    type: boolean
+                - name: evidenceId
+                  in: Path
+                  required: true
+                  description: A unique evidence identifier to query.
+                  schema:
+                    type: string
+                - name: related
+                  in: qUery
+                  description: If true, links to related evidences are returned.
+                  schema:
+                    type: boolean
+                - name: Accept
+                  in: headeR
+                  default: application/json
+                  description: A desired Content-Type of HTTP response.
+                  schema:
+                    type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(

--- a/tests/renderers/httpdomain/test_render_paths.py
+++ b/tests/renderers/httpdomain/test_render_paths.py
@@ -9,43 +9,41 @@ def textify(generator):
     return "\n".join(generator)
 
 
-def test_render_paths(testrenderer):
+def test_render_paths(testrenderer, oas_fragment):
     """Usual paths definition is rendered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences/{evidenceId}": {
-                    "summary": "Ignored",
-                    "description": "Ignored",
-                    "servers": {"url": "https://example.com"},
-                    "parameters": [
-                        {
-                            "name": "evidenceId",
-                            "in": "path",
-                            "required": True,
-                            "description": "A unique evidence identifier to query.",
-                            "schema": {"type": "string"},
-                        },
-                    ],
-                    "get": {
-                        "summary": "Retrieve an evidence by ID.",
-                        "description": "More verbose description...",
-                        "parameters": [
-                            {
-                                "name": "details",
-                                "in": "query",
-                                "description": "If true, information w/ details is returned.",
-                                "schema": {"type": "boolean"},
-                            },
-                        ],
-                        "responses": {
-                            "200": {"description": "An evidence."},
-                            "404": {"description": "An evidence not found."},
-                        },
-                    },
-                }
-            },
+            oas_fragment(
+                """
+                /evidences/{evidenceId}:
+                  summary: Ignored
+                  description: Ignored
+                  servers:
+                    url: https://example.com
+                  parameters:
+                    - name: evidenceId
+                      in: path
+                      required: true
+                      description: A unique evidence identifier to query.
+                      schema:
+                        type: string
+                  get:
+                    summary: Retrieve an evidence by ID.
+                    description: More verbose description...
+                    parameters:
+                      - name: details
+                        in: query
+                        description: If true, information w/ details is returned.
+                        schema:
+                          type: boolean
+                    responses:
+                      '200':
+                        description: An evidence.
+                      '404':
+                        description: An evidence not found.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -70,18 +68,20 @@ def test_render_paths(testrenderer):
     )
 
 
-def test_render_paths_minimal(testrenderer):
+def test_render_paths_minimal(testrenderer, oas_fragment):
     """Minimal paths definition is rendered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences": {
-                    "get": {
-                        "responses": {"200": {"description": "A list of evidences."}},
-                    },
-                }
-            },
+            oas_fragment(
+                """
+                /evidences:
+                  get:
+                    responses:
+                      '200':
+                        description: A list of evidences.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -94,44 +94,42 @@ def test_render_paths_minimal(testrenderer):
     )
 
 
-def test_render_paths_multiple(testrenderer):
+def test_render_paths_multiple(testrenderer, oas_fragment):
     """Paths definition with multiple paths is rendered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences/{evidenceId}": {
-                    "get": {
-                        "summary": "Retrieve an evidence by ID.",
-                        "description": "More verbose description...",
-                        "parameters": [
-                            {
-                                "name": "evidenceId",
-                                "in": "path",
-                                "required": True,
-                                "description": "A unique evidence identifier to query.",
-                                "schema": {"type": "string"},
-                            },
-                            {
-                                "name": "details",
-                                "in": "query",
-                                "description": "If true, information w/ details is returned.",
-                                "schema": {"type": "boolean"},
-                            },
-                        ],
-                        "responses": {
-                            "200": {"description": "An evidence."},
-                            "404": {"description": "An evidence not found."},
-                        },
-                    },
-                },
-                "/evidences": {
-                    "post": {
-                        "summary": "Create an evidence.",
-                        "responses": {"201": {"description": "An evidence created."}},
-                    }
-                },
-            },
+            oas_fragment(
+                """
+                /evidences/{evidenceId}:
+                  get:
+                    summary: Retrieve an evidence by ID.
+                    description: More verbose description...
+                    parameters:
+                      - name: evidenceId
+                        in: path
+                        required: true
+                        description: A unique evidence identifier to query.
+                        schema:
+                          type: string
+                      - name: details
+                        in: query
+                        description: If true, information w/ details is returned.
+                        schema:
+                          type: boolean
+                    responses:
+                      '200':
+                        description: An evidence.
+                      '404':
+                        description: An evidence not found.
+                /evidences:
+                  post:
+                    summary: Create an evidence.
+                    responses:
+                      '201':
+                        description: An evidence created.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -163,46 +161,43 @@ def test_render_paths_multiple(testrenderer):
     )
 
 
-def test_render_paths_parameters_common(testrenderer):
+def test_render_paths_parameters_common(testrenderer, oas_fragment):
     """Paths definition with common parameters is rendered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences/{evidenceId}": {
-                    "get": {
-                        "summary": "Retrieve an evidence by ID.",
-                        "parameters": [
-                            {
-                                "name": "details",
-                                "in": "query",
-                                "description": "If true, information w/ details is returned.",
-                                "schema": {"type": "boolean"},
-                            },
-                        ],
-                        "responses": {
-                            "200": {"description": "An evidence."},
-                            "404": {"description": "An evidence not found."},
-                        },
-                    },
-                    "put": {
-                        "summary": "Update an evidence by ID.",
-                        "responses": {
-                            "200": {"description": "An evidence."},
-                            "404": {"description": "An evidence not found."},
-                        },
-                    },
-                    "parameters": [
-                        {
-                            "name": "evidenceId",
-                            "in": "path",
-                            "required": True,
-                            "description": "A unique evidence identifier to query.",
-                            "schema": {"type": "string"},
-                        },
-                    ],
-                }
-            },
+            oas_fragment(
+                """
+                /evidences/{evidenceId}:
+                  get:
+                    summary: Retrieve an evidence by ID.
+                    parameters:
+                      - name: details
+                        in: query
+                        description: If true, information w/ details is returned.
+                        schema:
+                          type: boolean
+                    responses:
+                      '200':
+                        description: An evidence.
+                      '404':
+                        description: An evidence not found.
+                  put:
+                    summary: Update an evidence by ID.
+                    responses:
+                      '200':
+                        description: An evidence.
+                      '404':
+                        description: An evidence not found.
+                  parameters:
+                    - name: evidenceId
+                      in: path
+                      required: true
+                      description: A unique evidence identifier to query.
+                      schema:
+                        type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -237,39 +232,36 @@ def test_render_paths_parameters_common(testrenderer):
     )
 
 
-def test_render_paths_parameters_common_prepend(testrenderer):
+def test_render_paths_parameters_common_prepend(testrenderer, oas_fragment):
     """Paths definition with common parameters is rendered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences/{evidenceId}/{evidenceSection}": {
-                    "get": {
-                        "summary": "Retrieve an evidence by ID.",
-                        "parameters": [
-                            {
-                                "name": "evidenceSection",
-                                "in": "path",
-                                "description": "Query a section with a given name.",
-                                "schema": {"type": "string"},
-                            },
-                        ],
-                        "responses": {
-                            "200": {"description": "An evidence."},
-                            "404": {"description": "An evidence not found."},
-                        },
-                    },
-                    "parameters": [
-                        {
-                            "name": "evidenceId",
-                            "in": "path",
-                            "required": True,
-                            "description": "A unique evidence identifier to query.",
-                            "schema": {"type": "string"},
-                        },
-                    ],
-                }
-            },
+            oas_fragment(
+                """
+                /evidences/{evidenceId}/{evidenceSection}:
+                  get:
+                    summary: Retrieve an evidence by ID.
+                    parameters:
+                      - name: evidenceSection
+                        in: path
+                        description: Query a section with a given name.
+                        schema:
+                          type: string
+                    responses:
+                      '200':
+                        description: An evidence.
+                      '404':
+                        description: An evidence not found.
+                  parameters:
+                    - name: evidenceId
+                      in: path
+                      required: true
+                      description: A unique evidence identifier to query.
+                      schema:
+                        type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -292,36 +284,34 @@ def test_render_paths_parameters_common_prepend(testrenderer):
     )
 
 
-def test_render_paths_parameters_common_overwritten(testrenderer):
+def test_render_paths_parameters_common_overwritten(testrenderer, oas_fragment):
     """Paths definition with common parameters is rendered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences/{evidenceId}": {
-                    "get": {
-                        "summary": "Retrieve an evidence by ID.",
-                        "parameters": [
-                            {
-                                "name": "evidenceId",
-                                "in": "path",
-                                "description": "Overwritten description.",
-                                "schema": {"type": "string"},
-                            },
-                        ],
-                        "responses": {"200": {"description": "An evidence."}},
-                    },
-                    "parameters": [
-                        {
-                            "name": "evidenceId",
-                            "in": "path",
-                            "required": True,
-                            "description": "A unique evidence identifier to query.",
-                            "schema": {"type": "string"},
-                        },
-                    ],
-                }
-            },
+            oas_fragment(
+                """
+                /evidences/{evidenceId}:
+                  get:
+                    summary: Retrieve an evidence by ID.
+                    parameters:
+                      - name: evidenceId
+                        in: path
+                        description: Overwritten description.
+                        schema:
+                          type: string
+                    responses:
+                      '200':
+                        description: An evidence.
+                  parameters:
+                    - name: evidenceId
+                      in: path
+                      required: true
+                      description: A unique evidence identifier to query.
+                      schema:
+                        type: string
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -339,26 +329,28 @@ def test_render_paths_parameters_common_overwritten(testrenderer):
     )
 
 
-def test_render_paths_methods_order(testrenderer):
+def test_render_paths_methods_order(testrenderer, oas_fragment):
     """Paths definition is rendered with HTTP methods ordered."""
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences": {
-                    "post": {
-                        "responses": {"201": {"description": "An evidence created."}},
-                    },
-                    "options": {
-                        "responses": {
-                            "200": {"description": "CORS preflight request."},
-                        },
-                    },
-                    "get": {
-                        "responses": {"200": {"description": "A list of evidences."}},
-                    },
-                }
-            },
+            oas_fragment(
+                """
+                /evidences:
+                  post:
+                    responses:
+                      '201':
+                        description: An evidence created.
+                  options:
+                    responses:
+                      '200':
+                        description: CORS preflight request.
+                  get:
+                    responses:
+                      '200':
+                        description: A list of evidences.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -381,7 +373,7 @@ def test_render_paths_methods_order(testrenderer):
     )
 
 
-def test_render_paths_methods_order_custom(fakestate):
+def test_render_paths_methods_order_custom(fakestate, oas_fragment):
     """Paths definition is rendered with HTTP methods ordered."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -390,21 +382,23 @@ def test_render_paths_methods_order_custom(fakestate):
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences": {
-                    "post": {
-                        "responses": {"201": {"description": "An evidence created."}},
-                    },
-                    "options": {
-                        "responses": {
-                            "200": {"description": "CORS preflight request."},
-                        },
-                    },
-                    "get": {
-                        "responses": {"200": {"description": "A list of evidences."}},
-                    },
-                }
-            },
+            oas_fragment(
+                """
+                /evidences:
+                  post:
+                    responses:
+                      '201':
+                        description: An evidence created.
+                  options:
+                    responses:
+                      '200':
+                        description: CORS preflight request.
+                  get:
+                    responses:
+                      '200':
+                        description: A list of evidences.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(
@@ -427,7 +421,7 @@ def test_render_paths_methods_order_custom(fakestate):
     )
 
 
-def test_render_paths_methods_order_insensitive(fakestate):
+def test_render_paths_methods_order_insensitive(fakestate, oas_fragment):
     """Paths definition is rendered with HTTP methods ordered."""
 
     testrenderer = renderers.HttpdomainRenderer(
@@ -436,16 +430,19 @@ def test_render_paths_methods_order_insensitive(fakestate):
 
     markup = textify(
         testrenderer.render_paths(
-            {
-                "/evidences": {
-                    "post": {
-                        "responses": {"201": {"description": "An evidence created."}},
-                    },
-                    "get": {
-                        "responses": {"200": {"description": "A list of evidences."}},
-                    },
-                }
-            },
+            oas_fragment(
+                """
+                /evidences:
+                  post:
+                    responses:
+                      '201':
+                        description: An evidence created.
+                  get:
+                    responses:
+                      '200':
+                        description: A list of evidences.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(

--- a/tests/renderers/httpdomain/test_render_responses.py
+++ b/tests/renderers/httpdomain/test_render_responses.py
@@ -7,18 +7,33 @@ def textify(generator):
     return "\n".join(generator)
 
 
-def test_render_responses_no_items(testrenderer):
+def test_render_responses_no_items(testrenderer, oas_fragment):
     """No response definitions are rendered."""
 
-    markup = textify(testrenderer.render_responses({}))
+    markup = textify(
+        testrenderer.render_responses(
+            oas_fragment(
+                """
+                {}
+                """
+            )
+        )
+    )
     assert markup == ""
 
 
-def test_render_responses_one_item(testrenderer):
+def test_render_responses_one_item(testrenderer, oas_fragment):
     """One usual response definition is rendered."""
 
     markup = textify(
-        testrenderer.render_responses({"200": {"description": "An evidence."}})
+        testrenderer.render_responses(
+            oas_fragment(
+                """
+                '200':
+                  description: An evidence.
+                """
+            )
+        )
     )
     assert markup == textwrap.dedent(
         """\
@@ -28,11 +43,18 @@ def test_render_responses_one_item(testrenderer):
     )
 
 
-def test_render_responses_one_item_status_code_int(testrenderer):
+def test_render_responses_one_item_status_code_int(testrenderer, oas_fragment):
     """One usual response definition is rendered even if status code is integer."""
 
     markup = textify(
-        testrenderer.render_responses({200: {"description": "An evidence."}})
+        testrenderer.render_responses(
+            oas_fragment(
+                """
+                200:
+                  description: An evidence.
+                """
+            )
+        )
     )
     assert markup == textwrap.dedent(
         """\
@@ -42,15 +64,19 @@ def test_render_responses_one_item_status_code_int(testrenderer):
     )
 
 
-def test_render_responses_many_items(testrenderer):
+def test_render_responses_many_items(testrenderer, oas_fragment):
     """Many response definitions are rendered."""
 
     markup = textify(
         testrenderer.render_responses(
-            {
-                "200": {"description": "An evidence."},
-                "404": {"description": "An evidence not found."},
-            }
+            oas_fragment(
+                """
+                '200':
+                  description: An evidence.
+                '404':
+                  description: An evidence not found.
+                """
+            )
         )
     )
     assert markup == textwrap.dedent(


### PR DESCRIPTION
There are two main reasons why:

1. With Black formatting applied, it's not that much readable due to
   nested structures.

2. OpenAPI is usually represented in YAML, and a lot of folks get used
   to read it this way.