### PR TITLE
Add drop-in test infrastructure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,42 @@
+import os
+import pathlib
 import textwrap
+
 import pytest
+import yaml
 
 from sphinx.application import Sphinx
+from sphinxcontrib.openapi import utils
+
+
+_testspecs_dir = pathlib.Path(os.path.dirname(__file__), "testspecs")
+_testspecs_v2_dir = _testspecs_dir.joinpath("v2.0")
+_testspecs_v3_dir = _testspecs_dir.joinpath("v3.0")
+
+_testspecs = [str(path.relative_to(_testspecs_dir)) for path in _testspecs_dir.glob("*/*")]
+_testspecs_v2 = [str(path.relative_to(_testspecs_dir)) for path in _testspecs_v2_dir.glob("*/*")]
+_testspecs_v3 = [str(path.relative_to(_testspecs_dir)) for path in _testspecs_v3_dir.glob("*/*")]
+
+
+def pytest_addoption(parser):
+    parser.addoption("--regenerate-rendered-specs", action="store_true")
+
+
+def pytest_collection_modifyitems(items):
+    items_new = []
+
+    for item in items:
+        has_mark = bool(list(item.iter_markers(name="regenerate_rendered_specs")))
+
+        if any(
+            [
+                item.config.getoption("--regenerate-rendered-specs") and has_mark,
+                not item.config.getoption("--regenerate-rendered-specs") and not has_mark,
+            ]
+        ):
+            items_new.append(item)
+
+    items[:] = items_new
 
 
 def _format_option_raw(key, val):
@@ -46,3 +81,19 @@ def run_sphinx(tmpdir):
         ).build()
 
     yield run
+
+
+@pytest.fixture(scope="function")
+def get_testspec():
+    def get_testspec(*args, encoding="utf-8", resolve_refs=True):
+        with _testspecs_dir.joinpath(*args).open(encoding=encoding) as f:
+            spec = yaml.safe_load(f)
+            if resolve_refs:
+                spec = utils._resolve_refs("", spec)
+            return spec
+    return get_testspec
+
+
+@pytest.fixture(scope="function", params=_testspecs)
+def testspec(request, get_testspec):
+    return request.param, get_testspec(request.param)

--- a/tests/renderers/httpdomain/rendered/v2.0/api-with-examples.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v2.0/api-with-examples.yaml.rst
@@ -1,0 +1,93 @@
+.. http:get:: /
+
+   **List API versions**
+
+   :statuscode 200:
+      200 300 response
+
+      .. sourcecode:: http
+
+         HTTP/1.1 200 OK
+         Content-Type: application/json
+
+         {
+             "versions": [
+                 {
+                     "status": "CURRENT",
+                     "updated": "2011-01-21T11:33:21Z",
+                     "id": "v2.0",
+                     "links": [
+                         {
+                             "href": "http://127.0.0.1:8774/v2/",
+                             "rel": "self"
+                         }
+                     ]
+                 },
+                 {
+                     "status": "EXPERIMENTAL",
+                     "updated": "2013-07-23T11:33:21Z",
+                     "id": "v3.0",
+                     "links": [
+                         {
+                             "href": "http://127.0.0.1:8774/v3/",
+                             "rel": "self"
+                         }
+                     ]
+                 }
+             ]
+         }
+   :statuscode 300:
+      200 300 response
+
+.. http:get:: /v2
+
+   **Show API version details**
+
+   :statuscode 200:
+      200 203 response
+
+      .. sourcecode:: http
+
+         HTTP/1.1 200 OK
+         Content-Type: application/json
+
+         {
+             "version": {
+                 "status": "CURRENT",
+                 "updated": "2011-01-21T11:33:21Z",
+                 "media-types": [
+                     {
+                         "base": "application/xml",
+                         "type": "application/vnd.openstack.compute+xml;version=2"
+                     },
+                     {
+                         "base": "application/json",
+                         "type": "application/vnd.openstack.compute+json;version=2"
+                     }
+                 ],
+                 "id": "v2.0",
+                 "links": [
+                     {
+                         "href": "http://127.0.0.1:8774/v2/",
+                         "rel": "self"
+                     },
+                     {
+                         "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                         "type": "application/pdf",
+                         "rel": "describedby"
+                     },
+                     {
+                         "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                         "type": "application/vnd.sun.wadl+xml",
+                         "rel": "describedby"
+                     },
+                     {
+                       "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                       "type": "application/vnd.sun.wadl+xml",
+                       "rel": "describedby"
+                     }
+                 ]
+             }
+         }
+   :statuscode 203:
+      200 203 response

--- a/tests/renderers/httpdomain/rendered/v2.0/petstore-expanded.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v2.0/petstore-expanded.yaml.rst
@@ -1,0 +1,51 @@
+.. http:get:: /pets
+
+   Returns all pets from the system that the user has access to
+
+   :queryparam tags:
+      tags to filter by
+   :queryparamtype tags: array
+   :queryparam limit:
+      maximum number of results to return
+   :queryparamtype limit: integer:int32
+   :statuscode 200:
+      pet response
+
+   :statuscode default:
+      unexpected error
+
+.. http:post:: /pets
+
+   Creates a new pet in the store.  Duplicates are allowed
+
+
+   :statuscode 200:
+      pet response
+
+   :statuscode default:
+      unexpected error
+
+.. http:get:: /pets/{id}
+
+   Returns a user based on a single ID, if the user does not have access to the pet
+
+   :param id:
+      ID of pet to fetch
+   :paramtype id: integer:int64, required
+   :statuscode 200:
+      pet response
+
+   :statuscode default:
+      unexpected error
+
+.. http:delete:: /pets/{id}
+
+   deletes a single pet based on the ID supplied
+
+   :param id:
+      ID of pet to delete
+   :paramtype id: integer:int64, required
+   :statuscode 204:
+      pet deleted
+   :statuscode default:
+      unexpected error

--- a/tests/renderers/httpdomain/rendered/v2.0/petstore.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v2.0/petstore.yaml.rst
@@ -1,0 +1,38 @@
+.. http:get:: /pets
+
+   **List all pets**
+
+   :queryparam limit:
+      How many items to return at one time (max 100)
+   :queryparamtype limit: integer:int32
+   :statuscode 200:
+      A paged array of pets
+
+
+   :resheader x-next:
+      A link to the next page of responses
+   :resheadertype x-next: string
+   :statuscode default:
+      unexpected error
+
+.. http:post:: /pets
+
+   **Create a pet**
+
+   :statuscode 201:
+      Null response
+   :statuscode default:
+      unexpected error
+
+.. http:get:: /pets/{petId}
+
+   **Info for a specific pet**
+
+   :param petId:
+      The id of the pet to retrieve
+   :paramtype petId: string, required
+   :statuscode 200:
+      Expected response to a valid request
+
+   :statuscode default:
+      unexpected error

--- a/tests/renderers/httpdomain/rendered/v2.0/uber.json.rst
+++ b/tests/renderers/httpdomain/rendered/v2.0/uber.json.rst
@@ -1,0 +1,103 @@
+.. http:get:: /products
+
+   **Product Types**
+
+   The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
+
+   :queryparam latitude:
+      Latitude component of location.
+   :queryparamtype latitude: number:double, required
+   :queryparam longitude:
+      Longitude component of location.
+   :queryparamtype longitude: number:double, required
+   :statuscode 200:
+      An array of products
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /estimates/price
+
+   **Price Estimates**
+
+   .. role:: raw-html-m2r(raw)
+      :format: html
+
+
+   The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.\ :raw-html-m2r:`<br>`\ :raw-html-m2r:`<br>`\ The response also includes low and high estimates, and the `ISO 4217 <http://en.wikipedia.org/wiki/ISO_4217>`_ currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.
+
+   :queryparam start_latitude:
+      Latitude component of start location.
+   :queryparamtype start_latitude: number:double, required
+   :queryparam start_longitude:
+      Longitude component of start location.
+   :queryparamtype start_longitude: number:double, required
+   :queryparam end_latitude:
+      Latitude component of end location.
+   :queryparamtype end_latitude: number:double, required
+   :queryparam end_longitude:
+      Longitude component of end location.
+   :queryparamtype end_longitude: number:double, required
+   :statuscode 200:
+      An array of price estimates by product
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /estimates/time
+
+   **Time Estimates**
+
+   The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.
+
+   :queryparam start_latitude:
+      Latitude component of start location.
+   :queryparamtype start_latitude: number:double, required
+   :queryparam start_longitude:
+      Longitude component of start location.
+   :queryparamtype start_longitude: number:double, required
+   :queryparam customer_uuid:
+      Unique customer identifier to be used for experience customization.
+   :queryparamtype customer_uuid: string:uuid
+   :queryparam product_id:
+      Unique identifier representing a specific product for a given latitude & longitude.
+   :queryparamtype product_id: string
+   :statuscode 200:
+      An array of products
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /me
+
+   **User Profile**
+
+   The User Profile endpoint returns information about the Uber user that has authorized with the application.
+
+   :statuscode 200:
+      Profile information for a user
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /history
+
+   **User Activity**
+
+   .. role:: raw-html-m2r(raw)
+      :format: html
+
+
+   The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.\ :raw-html-m2r:`<br>`\ :raw-html-m2r:`<br>`\ The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.
+
+   :queryparam offset:
+      Offset the list of returned results by this amount. Default is zero.
+   :queryparamtype offset: integer:int32
+   :queryparam limit:
+      Number of items to retrieve. Default is 5, maximum is 100.
+   :queryparamtype limit: integer:int32
+   :statuscode 200:
+      History information for the given user
+
+   :statuscode default:
+      Unexpected error

--- a/tests/renderers/httpdomain/rendered/v2.0/uber.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v2.0/uber.yaml.rst
@@ -1,0 +1,103 @@
+.. http:get:: /products
+
+   **Product Types**
+
+   The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
+
+   :queryparam latitude:
+      Latitude component of location.
+   :queryparamtype latitude: number:double, required
+   :queryparam longitude:
+      Longitude component of location.
+   :queryparamtype longitude: number:double, required
+   :statuscode 200:
+      An array of products
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /estimates/price
+
+   **Price Estimates**
+
+   .. role:: raw-html-m2r(raw)
+      :format: html
+
+
+   The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.\ :raw-html-m2r:`<br>`\ :raw-html-m2r:`<br>`\ The response also includes low and high estimates, and the `ISO 4217 <http://en.wikipedia.org/wiki/ISO_4217>`_ currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.
+
+   :queryparam start_latitude:
+      Latitude component of start location.
+   :queryparamtype start_latitude: number:double, required
+   :queryparam start_longitude:
+      Longitude component of start location.
+   :queryparamtype start_longitude: number:double, required
+   :queryparam end_latitude:
+      Latitude component of end location.
+   :queryparamtype end_latitude: number:double, required
+   :queryparam end_longitude:
+      Longitude component of end location.
+   :queryparamtype end_longitude: number:double, required
+   :statuscode 200:
+      An array of price estimates by product
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /estimates/time
+
+   **Time Estimates**
+
+   The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.
+
+   :queryparam start_latitude:
+      Latitude component of start location.
+   :queryparamtype start_latitude: number:double, required
+   :queryparam start_longitude:
+      Longitude component of start location.
+   :queryparamtype start_longitude: number:double, required
+   :queryparam customer_uuid:
+      Unique customer identifier to be used for experience customization.
+   :queryparamtype customer_uuid: string:uuid
+   :queryparam product_id:
+      Unique identifier representing a specific product for a given latitude & longitude.
+   :queryparamtype product_id: string
+   :statuscode 200:
+      An array of products
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /me
+
+   **User Profile**
+
+   The User Profile endpoint returns information about the Uber user that has authorized with the application.
+
+   :statuscode 200:
+      Profile information for a user
+
+   :statuscode default:
+      Unexpected error
+
+.. http:get:: /history
+
+   **User Activity**
+
+   .. role:: raw-html-m2r(raw)
+      :format: html
+
+
+   The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.\ :raw-html-m2r:`<br>`\ :raw-html-m2r:`<br>`\ The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.
+
+   :queryparam offset:
+      Offset the list of returned results by this amount. Default is zero.
+   :queryparamtype offset: integer:int32
+   :queryparam limit:
+      Number of items to retrieve. Default is 5, maximum is 100.
+   :queryparamtype limit: integer:int32
+   :statuscode 200:
+      History information for the given user
+
+   :statuscode default:
+      Unexpected error

--- a/tests/renderers/httpdomain/rendered/v3.0/api-with-examples.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v3.0/api-with-examples.yaml.rst
@@ -1,0 +1,93 @@
+.. http:get:: /
+
+   **List API versions**
+
+   :statuscode 200:
+      200 response
+
+      .. sourcecode:: http
+
+         HTTP/1.1 200 OK
+         Content-Type: application/json
+
+         {
+           "versions": [
+             {
+               "status": "CURRENT",
+               "updated": "2011-01-21T11:33:21Z",
+               "id": "v2.0",
+               "links": [
+                 {
+                   "href": "http://127.0.0.1:8774/v2/",
+                   "rel": "self"
+                 }
+               ]
+             },
+             {
+               "status": "EXPERIMENTAL",
+               "updated": "2013-07-23T11:33:21Z",
+               "id": "v3.0",
+               "links": [
+                 {
+                   "href": "http://127.0.0.1:8774/v3/",
+                   "rel": "self"
+                 }
+               ]
+             }
+           ]
+         }
+   :statuscode 300:
+      300 response
+
+.. http:get:: /v2
+
+   **Show API version details**
+
+   :statuscode 200:
+      200 response
+
+      .. sourcecode:: http
+
+         HTTP/1.1 200 OK
+         Content-Type: application/json
+
+         {
+           "version": {
+             "status": "CURRENT",
+             "updated": "2011-01-21T11:33:21Z",
+             "media-types": [
+               {
+                 "base": "application/xml",
+                 "type": "application/vnd.openstack.compute+xml;version=2"
+               },
+               {
+                 "base": "application/json",
+                 "type": "application/vnd.openstack.compute+json;version=2"
+               }
+             ],
+             "id": "v2.0",
+             "links": [
+               {
+                 "href": "http://127.0.0.1:8774/v2/",
+                 "rel": "self"
+               },
+               {
+                 "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                 "type": "application/pdf",
+                 "rel": "describedby"
+               },
+               {
+                 "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                 "type": "application/vnd.sun.wadl+xml",
+                 "rel": "describedby"
+               },
+               {
+                 "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                 "type": "application/vnd.sun.wadl+xml",
+                 "rel": "describedby"
+               }
+             ]
+           }
+         }
+   :statuscode 203:
+      203 response

--- a/tests/renderers/httpdomain/rendered/v3.0/petstore-expanded.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v3.0/petstore-expanded.yaml.rst
@@ -1,0 +1,54 @@
+.. http:get:: /pets
+
+   Returns all pets from the system that the user has access to
+   Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+   Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+
+   :queryparam tags:
+      tags to filter by
+   :queryparamtype tags: array
+   :queryparam limit:
+      maximum number of results to return
+   :queryparamtype limit: integer:int32
+   :statuscode 200:
+      pet response
+
+   :statuscode default:
+      unexpected error
+
+.. http:post:: /pets
+
+   Creates a new pet in the store.  Duplicates are allowed
+
+
+   :statuscode 200:
+      pet response
+
+   :statuscode default:
+      unexpected error
+
+.. http:get:: /pets/{id}
+
+   Returns a user based on a single ID, if the user does not have access to the pet
+
+   :param id:
+      ID of pet to fetch
+   :paramtype id: integer:int64, required
+   :statuscode 200:
+      pet response
+
+   :statuscode default:
+      unexpected error
+
+.. http:delete:: /pets/{id}
+
+   deletes a single pet based on the ID supplied
+
+   :param id:
+      ID of pet to delete
+   :paramtype id: integer:int64, required
+   :statuscode 204:
+      pet deleted
+   :statuscode default:
+      unexpected error

--- a/tests/renderers/httpdomain/rendered/v3.0/petstore.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v3.0/petstore.yaml.rst
@@ -1,0 +1,38 @@
+.. http:get:: /pets
+
+   **List all pets**
+
+   :queryparam limit:
+      How many items to return at one time (max 100)
+   :queryparamtype limit: integer:int32
+   :statuscode 200:
+      A paged array of pets
+
+
+   :resheader x-next:
+      A link to the next page of responses
+   :resheadertype x-next: string
+   :statuscode default:
+      unexpected error
+
+.. http:post:: /pets
+
+   **Create a pet**
+
+   :statuscode 201:
+      Null response
+   :statuscode default:
+      unexpected error
+
+.. http:get:: /pets/{petId}
+
+   **Info for a specific pet**
+
+   :param petId:
+      The id of the pet to retrieve
+   :paramtype petId: string, required
+   :statuscode 200:
+      Expected response to a valid request
+
+   :statuscode default:
+      unexpected error

--- a/tests/renderers/httpdomain/rendered/v3.0/uspto.yaml.rst
+++ b/tests/renderers/httpdomain/rendered/v3.0/uspto.yaml.rst
@@ -1,0 +1,66 @@
+.. http:get:: /
+
+   **List available data sets**
+
+   :statuscode 200:
+      Returns a list of data sets
+
+      .. sourcecode:: http
+
+         HTTP/1.1 200 OK
+         Content-Type: application/json
+
+         {
+           "total": 2,
+           "apis": [
+             {
+               "apiKey": "oa_citations",
+               "apiVersionNumber": "v1",
+               "apiUrl": "https://developer.uspto.gov/ds-api/oa_citations/v1/fields",
+               "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/oa_citations.json"
+             },
+             {
+               "apiKey": "cancer_moonshot",
+               "apiVersionNumber": "v1",
+               "apiUrl": "https://developer.uspto.gov/ds-api/cancer_moonshot/v1/fields",
+               "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/cancer_moonshot.json"
+             }
+           ]
+         }
+
+.. http:get:: /{dataset}/{version}/fields
+
+   **Provides the general information about the API and the list of fields that can be used to query the dataset.**
+
+   This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
+
+   :param dataset:
+      Name of the dataset.
+   :paramtype dataset: string, required
+   :param version:
+      Version of the dataset.
+   :paramtype version: string, required
+   :statuscode 200:
+      The dataset API for the given version is found and it is accessible to consume.
+
+   :statuscode 404:
+      The combination of dataset name and version is not found in the system or it is not published yet to be consumed by public.
+
+.. http:post:: /{dataset}/{version}/records
+
+   **Provides search capability for the data set with the given search criteria.**
+
+   This API is based on Solr/Lucense Search. The data is indexed using SOLR. This GET API returns the list of all the searchable field names that are in the Solr Index. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the Solr/Lucene Syntax. Please refer https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the query syntax. List of field names that are searchable can be determined using above GET api.
+
+   :param version:
+      Version of the dataset.
+   :paramtype version: string, required
+   :param dataset:
+      Name of the dataset. In this case, the default value is oa_citations
+   :paramtype dataset: string, required
+
+   :statuscode 200:
+      successful operation
+
+   :statuscode 404:
+      No matching record found for the given criteria.

--- a/tests/renderers/httpdomain/test_render.py
+++ b/tests/renderers/httpdomain/test_render.py
@@ -1,0 +1,25 @@
+import pathlib
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def rendered():
+    return pathlib.Path(os.path.dirname(__file__), "rendered")
+
+
+@pytest.mark.regenerate_rendered_specs
+def test_generate(testrenderer, testspec, rendered):
+    testspec_name, testspec = testspec
+    rendered_markup = "\n".join(testrenderer.render_restructuredtext_markup(testspec))
+
+    rendered.joinpath(os.path.dirname(testspec_name)).mkdir(parents=True, exist_ok=True)
+    rendered.joinpath(testspec_name + ".rst").write_text(rendered_markup)
+
+
+def test_render(testrenderer, testspec, rendered):
+    testspec_name, testspec = testspec
+    rendered_markup = "\n".join(testrenderer.render_restructuredtext_markup(testspec))
+
+    assert rendered_markup == rendered.joinpath(testspec_name + ".rst").read_text()

--- a/tests/testspecs/v2.0/api-with-examples.yaml
+++ b/tests/testspecs/v2.0/api-with-examples.yaml
@@ -1,0 +1,164 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: v2
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: |-
+            200 300 response
+          examples:
+            application/json: |-
+              {
+                  "versions": [
+                      {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                              {
+                                  "href": "http://127.0.0.1:8774/v2/",
+                                  "rel": "self"
+                              }
+                          ]
+                      },
+                      {
+                          "status": "EXPERIMENTAL",
+                          "updated": "2013-07-23T11:33:21Z",
+                          "id": "v3.0",
+                          "links": [
+                              {
+                                  "href": "http://127.0.0.1:8774/v3/",
+                                  "rel": "self"
+                              }
+                          ]
+                      }
+                  ]
+              }
+        "300":
+          description: |-
+            200 300 response
+          examples:
+            application/json: |-
+              {
+                  "versions": [
+                      {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                              {
+                                  "href": "http://127.0.0.1:8774/v2/",
+                                  "rel": "self"
+                              }
+                          ]
+                      },
+                      {
+                          "status": "EXPERIMENTAL",
+                          "updated": "2013-07-23T11:33:21Z",
+                          "id": "v3.0",
+                          "links": [
+                              {
+                                  "href": "http://127.0.0.1:8774/v3/",
+                                  "rel": "self"
+                              }
+                          ]
+                      }
+                  ]
+              }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: |-
+            200 203 response
+          examples:
+            application/json: |-
+              {
+                  "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                          {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          },
+                          {
+                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                            "type": "application/vnd.sun.wadl+xml",
+                            "rel": "describedby"
+                          }
+                      ]
+                  }
+              }
+        "203":
+          description: |-
+            200 203 response
+          examples:
+            application/json: |-
+              {
+                  "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                          {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          }
+                      ]
+                  }
+              }
+consumes:
+- application/json

--- a/tests/testspecs/v2.0/petstore-expanded.yaml
+++ b/tests/testspecs/v2.0/petstore-expanded.yaml
@@ -1,0 +1,139 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: '#/definitions/NewPet'
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "204":
+          description: pet deleted
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    allOf:
+      - $ref: '#/definitions/NewPet'
+      - required:
+        - id
+        properties:
+          id:
+            type: integer
+            format: int64
+
+  NewPet:
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/tests/testspecs/v2.0/petstore.yaml
+++ b/tests/testspecs/v2.0/petstore.yaml
@@ -1,0 +1,101 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/tests/testspecs/v2.0/uber.json
+++ b/tests/testspecs/v2.0/uber.json
@@ -1,0 +1,370 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uber API",
+    "description": "Move your app forward with the Uber API",
+    "version": "1.0.0"
+  },
+  "host": "api.uber.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/products": {
+      "get": {
+        "summary": "Product Types",
+        "description": "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "description": "Latitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "description": "Longitude component of location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/price": {
+      "get": {
+        "summary": "Price Estimates",
+        "description": "The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.",
+        "parameters": [
+          {
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_latitude",
+            "in": "query",
+            "description": "Latitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "end_longitude",
+            "in": "query",
+            "description": "Longitude component of end location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of price estimates by product",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PriceEstimate"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/estimates/time": {
+      "get": {
+        "summary": "Time Estimates",
+        "description": "The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.",
+        "parameters": [
+          {
+            "name": "start_latitude",
+            "in": "query",
+            "description": "Latitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "start_longitude",
+            "in": "query",
+            "description": "Longitude component of start location.",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "customer_uuid",
+            "in": "query",
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique customer identifier to be used for experience customization."
+          },
+          {
+            "name": "product_id",
+            "in": "query",
+            "type": "string",
+            "description": "Unique identifier representing a specific product for a given latitude & longitude."
+          }
+        ],
+        "tags": [
+          "Estimates"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "summary": "User Profile",
+        "description": "The User Profile endpoint returns information about the Uber user that has authorized with the application.",
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "Profile information for a user",
+            "schema": {
+              "$ref": "#/definitions/Profile"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/history": {
+      "get": {
+        "summary": "User Activity",
+        "description": "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.",
+        "parameters": [
+          {
+            "name": "offset",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Offset the list of returned results by this amount. Default is zero."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of items to retrieve. Default is 5, maximum is 100."
+          }
+        ],
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "200": {
+            "description": "History information for the given user",
+            "schema": {
+              "$ref": "#/definitions/Activities"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "capacity": {
+          "type": "string",
+          "description": "Capacity of product. For example, 4 people."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image URL representing the product."
+        }
+      }
+    },
+    "PriceEstimate": {
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles"
+        },
+        "currency_code": {
+          "type": "string",
+          "description": "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code."
+        },
+        "display_name": {
+          "type": "string",
+          "description": "Display name of product."
+        },
+        "estimate": {
+          "type": "string",
+          "description": "Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or \"Metered\" for TAXI."
+        },
+        "low_estimate": {
+          "type": "number",
+          "description": "Lower bound of the estimated price."
+        },
+        "high_estimate": {
+          "type": "number",
+          "description": "Upper bound of the estimated price."
+        },
+        "surge_multiplier": {
+          "type": "number",
+          "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier."
+        }
+      }
+    },
+    "Profile": {
+      "properties": {
+        "first_name": {
+          "type": "string",
+          "description": "First name of the Uber user."
+        },
+        "last_name": {
+          "type": "string",
+          "description": "Last name of the Uber user."
+        },
+        "email": {
+          "type": "string",
+          "description": "Email address of the Uber user"
+        },
+        "picture": {
+          "type": "string",
+          "description": "Image URL of the Uber user."
+        },
+        "promo_code": {
+          "type": "string",
+          "description": "Promo code of the Uber user."
+        }
+      }
+    },
+    "Activity": {
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "Unique identifier for the activity"
+        }
+      }
+    },
+    "Activities": {
+      "properties": {
+        "offset": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Position in pagination."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of items to retrieve (100 max)."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items available."
+        },
+        "history": {
+          "type": "array",
+          "items": {
+              "$ref": "#/definitions/Activity"
+           }
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/testspecs/v2.0/uber.yaml
+++ b/tests/testspecs/v2.0/uber.yaml
@@ -1,0 +1,273 @@
+# this is an example of the Uber API
+# as a demonstration of an API spec in YAML
+swagger: "2.0"
+info:
+  title: Uber API
+  description: Move your app forward with the Uber API
+  version: "1.0.0"
+# the domain of the service
+host: api.uber.com
+# array of all schemes that your API supports
+schemes:
+  - https
+# will be prefixed to all paths
+basePath: /v1
+securityDefinitions:
+  apikey:
+    type: apiKey
+    name: server_token
+    in: query
+produces:
+  - application/json
+paths:
+  /products:
+    get:
+      summary: Product Types
+      description: The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
+      parameters:
+        - name: latitude
+          in: query
+          description: Latitude component of location.
+          required: true
+          type: number
+          format: double
+        - name: longitude
+          in: query
+          description: Longitude component of location.
+          required: true
+          type: number
+          format: double
+      security:
+        - apikey: []
+      tags:
+        - Products
+      responses:
+        "200":
+          description: An array of products
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Product'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /estimates/price:
+    get:
+      summary: Price Estimates
+      description: The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.
+      parameters:
+        - name: start_latitude
+          in: query
+          description: Latitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: start_longitude
+          in: query
+          description: Longitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: end_latitude
+          in: query
+          description: Latitude component of end location.
+          required: true
+          type: number
+          format: double
+        - name: end_longitude
+          in: query
+          description: Longitude component of end location.
+          required: true
+          type: number
+          format: double
+      tags:
+        - Estimates
+      responses:
+        "200":
+          description: An array of price estimates by product
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PriceEstimate'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /estimates/time:
+    get:
+      summary: Time Estimates
+      description: The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.
+      parameters:
+        - name: start_latitude
+          in: query
+          description: Latitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: start_longitude
+          in: query
+          description: Longitude component of start location.
+          required: true
+          type: number
+          format: double
+        - name: customer_uuid
+          in: query
+          type: string
+          format: uuid
+          description: Unique customer identifier to be used for experience customization.
+        - name: product_id
+          in: query
+          type: string
+          description: Unique identifier representing a specific product for a given latitude & longitude.
+      tags:
+        - Estimates
+      responses:
+        "200":
+          description: An array of products
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Product'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /me:
+    get:
+      summary: User Profile
+      description: The User Profile endpoint returns information about the Uber user that has authorized with the application.
+      tags:
+        - User
+      responses:
+        "200":
+          description: Profile information for a user
+          schema:
+            $ref: '#/definitions/Profile'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /history:
+    get:
+      summary: User Activity
+      description: The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.
+      parameters:
+        - name: offset
+          in: query
+          type: integer
+          format: int32
+          description: Offset the list of returned results by this amount. Default is zero.
+        - name: limit
+          in: query
+          type: integer
+          format: int32
+          description: Number of items to retrieve. Default is 5, maximum is 100.
+      tags:
+        - User
+      responses:
+        "200":
+          description: History information for the given user
+          schema:
+            $ref: '#/definitions/Activities'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Product:
+    properties:
+      product_id:
+        type: string
+        description: Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+      description:
+        type: string
+        description: Description of product.
+      display_name:
+        type: string
+        description: Display name of product.
+      capacity:
+        type: integer
+        description: Capacity of product. For example, 4 people.
+      image:
+        type: string
+        description: Image URL representing the product.
+  ProductList:
+    properties:
+      products:
+        description: Contains the list of products
+        type: array
+        items:
+          $ref: "#/definitions/Product"
+  PriceEstimate:
+    properties:
+      product_id:
+        type: string
+        description: Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
+      currency_code:
+        type: string
+        description: "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code."
+      display_name:
+        type: string
+        description: Display name of product.
+      estimate:
+        type: string
+        description: Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
+      low_estimate:
+        type: number
+        description: Lower bound of the estimated price.
+      high_estimate:
+        type: number
+        description: Upper bound of the estimated price.
+      surge_multiplier:
+        type: number
+        description: Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
+  Profile:
+    properties:
+      first_name:
+        type: string
+        description: First name of the Uber user.
+      last_name:
+        type: string
+        description: Last name of the Uber user.
+      email:
+        type: string
+        description: Email address of the Uber user
+      picture:
+        type: string
+        description: Image URL of the Uber user.
+      promo_code:
+        type: string
+        description: Promo code of the Uber user.
+  Activity:
+    properties:
+      uuid:
+        type: string
+        description: Unique identifier for the activity
+  Activities:
+    properties:
+      offset:
+        type: integer
+        format: int32
+        description: Position in pagination.
+      limit:
+        type: integer
+        format: int32
+        description: Number of items to retrieve (100 max).
+      count:
+        type: integer
+        format: int32
+        description: Total number of items available.
+      history:
+        type: array
+        items:
+          $ref: '#/definitions/Activity'
+  Error:
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string

--- a/tests/testspecs/v3.0/api-with-examples.yaml
+++ b/tests/testspecs/v3.0/api-with-examples.yaml
@@ -1,0 +1,167 @@
+openapi: "3.0.0"
+info:
+  title: Simple API overview
+  version: 2.0.0
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: {
+                    "versions": [
+                        {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                 }
+        '300':
+          description: |-
+            300 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: |
+                   {
+                    "versions": [
+                          {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                   }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: {
+                    "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                          {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          },
+                          {
+                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                            "type": "application/vnd.sun.wadl+xml",
+                            "rel": "describedby"
+                          }
+                      ]
+                    }
+                  }
+        '203':
+          description: |-
+            203 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: {
+                    "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                          {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          }
+                      ]
+                    }
+                  }

--- a/tests/testspecs/v3.0/petstore-expanded.yaml
+++ b/tests/testspecs/v3.0/petstore-expanded.yaml
@@ -1,0 +1,155 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/testspecs/v3.0/petstore.yaml
+++ b/tests/testspecs/v3.0/petstore.yaml
@@ -1,0 +1,109 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/testspecs/v3.0/uspto.yaml
+++ b/tests/testspecs/v3.0/uspto.yaml
@@ -1,0 +1,210 @@
+openapi: 3.0.1
+servers:
+  - url: '{scheme}://developer.uspto.gov/ds-api'
+    variables:
+      scheme:
+        description: 'The Data Set API is accessible via https and http'
+        enum:
+          - 'https'
+          - 'http'
+        default: 'https'
+info:
+  description: >-
+    The Data Set API (DSAPI) allows the public users to discover and search
+    USPTO exported data sets. This is a generic API that allows USPTO users to
+    make any CSV based data files searchable through API. With the help of GET
+    call, it returns the list of data fields that are searchable. With the help
+    of POST call, data can be fetched based on the filters on the field names.
+    Please note that POST call is used to search the actual data. The reason for
+    the POST call is that it allows users to specify any complex search criteria
+    without worry about the GET size limitations as well as encoding of the
+    input parameters.
+  version: 1.0.0
+  title: USPTO Data Set API
+  contact:
+    name: Open Data Portal
+    url: 'https://developer.uspto.gov'
+    email: developer@uspto.gov
+tags:
+  - name: metadata
+    description: Find out about the data sets
+  - name: search
+    description: Search a data set
+paths:
+  /:
+    get:
+      tags:
+        - metadata
+      operationId: list-data-sets
+      summary: List available data sets
+      responses:
+        '200':
+          description: Returns a list of data sets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dataSetList'
+              example:
+                {
+                  "total": 2,
+                  "apis": [
+                    {
+                      "apiKey": "oa_citations",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/oa_citations/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/oa_citations.json"
+                    },
+                    {
+                      "apiKey": "cancer_moonshot",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/cancer_moonshot/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/cancer_moonshot.json"
+                    }
+                  ]
+                }
+  /{dataset}/{version}/fields:
+    get:
+      tags:
+        - metadata
+      summary: >-
+        Provides the general information about the API and the list of fields
+        that can be used to query the dataset.
+      description: >-
+        This GET API returns the list of all the searchable field names that are
+        in the oa_citations. Please see the 'fields' attribute which returns an
+        array of field names. Each field or a combination of fields can be
+        searched using the syntax options shown below.
+      operationId: list-searchable-fields
+      parameters:
+        - name: dataset
+          in: path
+          description: 'Name of the dataset.'
+          required: true
+          example: "oa_citations"
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          example: "v1"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            The dataset API for the given version is found and it is accessible
+            to consume.
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: >-
+            The combination of dataset name and version is not found in the
+            system or it is not published yet to be consumed by public.
+          content:
+            application/json:
+              schema:
+                type: string
+  /{dataset}/{version}/records:
+    post:
+      tags:
+        - search
+      summary: >-
+        Provides search capability for the data set with the given search
+        criteria.
+      description: >-
+        This API is based on Solr/Lucense Search. The data is indexed using
+        SOLR. This GET API returns the list of all the searchable field names
+        that are in the Solr Index. Please see the 'fields' attribute which
+        returns an array of field names. Each field or a combination of fields
+        can be searched using the Solr/Lucene Syntax. Please refer
+        https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for
+        the query syntax. List of field names that are searchable can be
+        determined using above GET api.
+      operationId: perform-search
+      parameters:
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          schema:
+            type: string
+            default: v1
+        - name: dataset
+          in: path
+          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          required: true
+          schema:
+            type: string
+            default: oa_citations
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: object
+        '404':
+          description: No matching record found for the given criteria.
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                criteria:
+                  description: >-
+                    Uses Lucene Query Syntax in the format of
+                    propertyName:value, propertyName:[num1 TO num2] and date
+                    range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the
+                    response please see the 'docs' element which has the list of
+                    record objects. Each record structure would consist of all
+                    the fields and their corresponding values.
+                  type: string
+                  default: '*:*'
+                start:
+                  description: Starting record number. Default value is 0.
+                  type: integer
+                  default: 0
+                rows:
+                  description: >-
+                    Specify number of rows to be returned. If you run the search
+                    with default values, in the response you will see 'numFound'
+                    attribute which will tell the number of records available in
+                    the dataset.
+                  type: integer
+                  default: 100
+              required:
+                - criteria
+components:
+  schemas:
+    dataSetList:
+      type: object
+      properties:
+        total:
+          type: integer
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              apiKey:
+                type: string
+                description: To be used as a dataset parameter value
+              apiVersionNumber:
+                type: string
+                description: To be used as a version parameter value
+              apiUrl:
+                type: string
+                format: uriref
+                description: "The URL describing the dataset's fields"
+              apiDocumentationUrl:
+                type: string
+                format: uriref
+                description: A URL to the API console for each API

--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,7 @@ commands =
 deps = sphinx_rtd_theme
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees docs docs/_build/
+
+[pytest]
+markers =
+    regenerate_rendered_specs


### PR DESCRIPTION
With drop-in test infrastructure, the new renderer test can be added as
simply as dropping an OpenAPI spec to a proper 'tests/testspecs'
directory.