### PR TITLE
Allow description to be optional

### DIFF
--- a/sphinxcontrib/openapi/openapi20.py
+++ b/sphinxcontrib/openapi/openapi20.py
@@ -57,7 +57,7 @@ def _httpresource(endpoint, method, properties, convert):
     # print response status codes
     for status, response in sorted(responses.items()):
         yield '{indent}:status {status}:'.format(**locals())
-        for line in convert(response['description']).splitlines():
+        for line in convert(response.get('description', '')).splitlines():
             yield '{indent}{indent}{line}'.format(**locals())
 
     # print request header params
@@ -70,7 +70,7 @@ def _httpresource(endpoint, method, properties, convert):
     for status, response in responses.items():
         for headername, header in response.get('headers', {}).items():
             yield indent + ':resheader {name}:'.format(name=headername)
-            for line in convert(header['description']).splitlines():
+            for line in convert(header.get('description', '')).splitlines():
                 yield '{indent}{indent}{line}'.format(**locals())
 
     for status, response in responses.items():

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -262,7 +262,7 @@ def _httpresource(endpoint, method, properties, convert, render_examples,
         yield ''
 
     if 'description' in properties:
-        for line in convert(properties['description']).splitlines():
+        for line in convert(properties.get('description', '')).splitlines():
             yield '{indent}{line}'.format(**locals())
         yield ''
 
@@ -330,7 +330,7 @@ def _httpresource(endpoint, method, properties, convert, render_examples,
     # print response status codes
     for status, response in responses.items():
         yield '{indent}:status {status}:'.format(**locals())
-        for line in convert(response['description']).splitlines():
+        for line in convert(response.get('description', '')).splitlines():
             yield '{indent}{indent}{line}'.format(**locals())
 
         # print response example
@@ -351,7 +351,7 @@ def _httpresource(endpoint, method, properties, convert, render_examples,
     for status, response in responses.items():
         for headername, header in response.get('headers', {}).items():
             yield indent + ':resheader {name}:'.format(name=headername)
-            for line in convert(header['description']).splitlines():
+            for line in convert(header.get('description', '')).splitlines():
                 yield '{indent}{indent}{line}'.format(**locals())
 
     for cb_name, cb_specs in properties.get('callbacks', {}).items():


### PR DESCRIPTION
I encountered this problem during the usage of this library in a project of mine. One endpoint was missing a description, which resulted in an build error.

This Pullrequest allows descriptions of any sort to be missing from the `openapi.json`. 

The Specification it self does not require those fields (see https://swagger.io/specification/), thus this library should not force the user to provide it.

I would greatly appreciate, if this proposal makes it way into the next release.

