### PR TITLE
openapi 3.0.0 improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "sphinxcontrib-httpdomain >= 1.5.0",
         "PyYAML >= 3.12",
         "jsonschema >= 2.5.1",
+        "mistune<2.0.0",
         "m2r >= 0.2",
         "picobox >= 2.2",
         "deepmerge >= 0.1",


### PR DESCRIPTION
openapi 3.0.0 improvements:
-  multipart/form-data request body printed
- show security Autorization headers with a nice lock unicode.
- print other request headers
- show content-type headers