### PR TITLE
fix: changed dictionary field access into get invocation

### DIFF
--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -351,7 +351,7 @@ def _httpresource(endpoint, method, properties, convert, render_examples,
     for status, response in responses.items():
         for headername, header in response.get('headers', {}).items():
             yield indent + ':resheader {name}:'.format(name=headername)
-            for line in convert(header['description']).splitlines():
+            for line in convert(header.get('description', '')).splitlines():
                 yield '{indent}{indent}{line}'.format(**locals())
 
     for cb_name, cb_specs in properties.get('callbacks', {}).items():


### PR DESCRIPTION
get() possibly null header 'description' item instead of accessing it by key and rasing KeyError

issue: https://github.com/sphinx-contrib/openapi/issues/130#issue-1402211100 