### PR TITLE
Migrate to native package namespaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "sphinx-mdinclude >= 0.5.2",
         "picobox >= 2.2",
         "deepmerge >= 0.1",
+        "importlib-metadata; python_version < '3.8'",
     ],
     project_urls={
         "Documentation": "https://sphinxcontrib-openapi.readthedocs.io/",
@@ -54,6 +55,5 @@ setup(
         "Framework :: Sphinx",
         "Framework :: Sphinx :: Extension",
     ],
-    namespace_packages=["sphinxcontrib"],
     python_requires=">=3.7",
 )

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -9,4 +9,4 @@
     :license: BSD, see LICENSE for details.
 """
 
-__import__("pkg_resources").declare_namespace(__name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/sphinxcontrib/openapi/__init__.py
+++ b/sphinxcontrib/openapi/__init__.py
@@ -9,12 +9,16 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pkg_resources import get_distribution, DistributionNotFound
+try:
+    from importlib.metadata import distribution, PackageNotFoundError
+except ImportError:  # python < 3.8
+    from importlib_metadata import distribution, PackageNotFoundError
+
 from sphinxcontrib.openapi import renderers, directive
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = distribution(__name__).version
+except PackageNotFoundError:
     # package is not installed
     __version__ = None
 


### PR DESCRIPTION
Start using `importlib.metadata` rather than the deprecated `pkg_utils`.
