### PR TITLE
Add initial OpenAPI 3.1 support

### DIFF
--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -27,7 +27,11 @@ from sphinxcontrib.openapi import utils
 
 LOG = logging.getLogger(__name__)
 
-# https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#data-types
+# Based on the spec:
+#
+# https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.0.0.md#data-types
+#
+# Note that array and object are excluded since these are handled separately
 _TYPE_MAPPING = {
     ('integer', 'int32'): 1,  # integer
     ('integer', 'int64'): 1,  # long

--- a/sphinxcontrib/openapi/openapi30.py
+++ b/sphinxcontrib/openapi/openapi30.py
@@ -2,7 +2,7 @@
     sphinxcontrib.openapi.openapi30
     -------------------------------
 
-    The OpenAPI 3.0.0 spec renderer. Based on ``sphinxcontrib-httpdomain``.
+    The OpenAPI 3.0 spec renderer. Based on ``sphinxcontrib-httpdomain``.
 
     :copyright: (c) 2016, Ihor Kalnytskyi.
     :license: BSD, see LICENSE for details.

--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -101,12 +101,23 @@ def _parse_schema(schema, method):
         return _parse_schema(schema_, method)
 
     # anyOf: Must be valid against any of the subschemas
-    # TODO(stephenfin): Handle anyOf
+    if "anyOf" in schema:
+        # we only show the one since we can't show everything, but we need to
+        # figure out which one
+        for sub_schema in schema["anyOf"]:
+            if sub_schema["type"] == "null":
+                continue
+
+            return _parse_schema(sub_schema, method)
 
     # oneOf: Must be valid against exactly one of the subschemas
     if "oneOf" in schema:
         # we only show the first one since we can't show everything
-        return _parse_schema(schema["oneOf"][0], method)
+        for sub_schema in schema["oneOf"]:
+            if sub_schema["type"] == "null":
+                continue
+
+            return _parse_schema(sub_schema, method)
 
     if "enum" in schema:
         # we only show the first one since we can't show everything

--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -246,7 +246,7 @@ def _example(media_type_objects, method=None, endpoint=None, status=None, nb_ind
 def _httpresource(
     endpoint, method, properties, convert, render_examples, render_request
 ):
-    # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#operation-object
+    # https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#operation-object
     parameters = properties.get("parameters", [])
     responses = properties["responses"]
     query_param_examples = []
@@ -394,6 +394,19 @@ def openapihttpdomain(spec, **options):
     # Paths list to be processed
     paths = []
 
+    # If a path-related option was provided, we need to first ensure we have
+    # paths within the spec; otherwise raise error and ask user to fix that.
+    if "paths" not in spec and (
+        "paths" in options
+        or "include" in options
+        or "exclude" in options
+        or "group" in options
+    ):
+        raise ValueError(
+            "Spec does not define any paths and the 'include', 'exclude', "
+            "'paths' and 'group' options are therefore invalid."
+        )
+
     # If 'paths' are passed we've got to ensure they exist within an OpenAPI
     # spec; otherwise raise error and ask user to fix that.
     if "paths" in options:
@@ -414,7 +427,7 @@ def openapihttpdomain(spec, **options):
 
     # If no include nor paths option, then take full path
     if "include" not in options and "paths" not in options:
-        paths = spec["paths"]
+        paths = spec.get("paths", [])
 
     # Remove paths matching regexp
     if "exclude" in options:
@@ -432,7 +445,7 @@ def openapihttpdomain(spec, **options):
 
     convert = utils.get_text_converter(options)
 
-    # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#paths-object
+    # https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#paths-object
     if "group" in options:
         groups = collections.OrderedDict(
             [(x["name"], []) for x in spec.get("tags", {})]

--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -27,7 +27,12 @@ from sphinxcontrib.openapi import utils
 
 LOG = logging.getLogger(__name__)
 
-# https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#data-types
+# Based on the spec:
+#
+# https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#dataTypes
+# https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1
+#
+# Note that array and object are excluded since these are handled separately
 _TYPE_MAPPING = {
     ("integer", "int32"): 1,  # integer
     ("integer", "int64"): 1,  # long
@@ -40,6 +45,7 @@ _TYPE_MAPPING = {
     ("string", "date"): datetime.now().date().isoformat(),  # date
     ("string", "date-time"): datetime.now().isoformat(),  # dateTime
     ("string", "password"): "********",  # password
+    ("null", None): None,  # null
     # custom extensions to handle common formats
     ("string", "email"): "name@example.com",
     ("string", "zip-code"): "90210",

--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -1,0 +1,476 @@
+"""
+    sphinxcontrib.openapi.openapi31
+    -------------------------------
+
+    The OpenAPI 3.1 spec renderer. Based on ``sphinxcontrib-httpdomain``.
+
+    :copyright: (c) 2016, Ihor Kalnytskyi.
+    :license: BSD, see LICENSE for details.
+"""
+
+import copy
+
+import collections
+import collections.abc
+
+from datetime import datetime
+import itertools
+import json
+import re
+from urllib import parse
+from http.client import responses as http_status_codes
+
+from sphinx.util import logging
+
+from sphinxcontrib.openapi import utils
+
+
+LOG = logging.getLogger(__name__)
+
+# https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#data-types
+_TYPE_MAPPING = {
+    ("integer", "int32"): 1,  # integer
+    ("integer", "int64"): 1,  # long
+    ("number", "float"): 1.0,  # float
+    ("number", "double"): 1.0,  # double
+    ("boolean", None): True,  # boolean
+    ("string", None): "string",  # string
+    ("string", "byte"): "c3RyaW5n",  # b'string' encoded in base64,  # byte
+    ("string", "binary"): "01010101",  # binary
+    ("string", "date"): datetime.now().date().isoformat(),  # date
+    ("string", "date-time"): datetime.now().isoformat(),  # dateTime
+    ("string", "password"): "********",  # password
+    # custom extensions to handle common formats
+    ("string", "email"): "name@example.com",
+    ("string", "zip-code"): "90210",
+    ("string", "uri"): "https://example.com",
+    # additional fallthrough cases
+    ("integer", None): 1,  # integer
+    ("number", None): 1.0,  # <fallthrough>
+}
+
+_READONLY_PROPERTY = object()  # sentinel for values not included in requests
+
+
+def _dict_merge(dct, merge_dct):
+    """Recursive dict merge.
+
+    Inspired by :meth:``dict.update()``, instead of updating only top-level
+    keys, dict_merge recurses down into dicts nested to an arbitrary depth,
+    updating keys. The ``merge_dct`` is merged into ``dct``.
+
+    From https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
+
+    Arguments:
+        dct: dict onto which the merge is executed
+        merge_dct: dct merged into dct
+    """
+    for k in merge_dct.keys():
+        if (
+            k in dct
+            and isinstance(dct[k], dict)
+            and isinstance(merge_dct[k], collections.abc.Mapping)
+        ):
+            _dict_merge(dct[k], merge_dct[k])
+        else:
+            dct[k] = merge_dct[k]
+
+
+def _parse_schema(schema, method):
+    """
+    Convert a Schema Object to a Python object.
+
+    Args:
+        schema: An ``OrderedDict`` representing the schema object.
+    """
+    if method and schema.get("readOnly", False):
+        return _READONLY_PROPERTY
+
+    # allOf: Must be valid against all of the subschemas
+    if "allOf" in schema:
+        schema_ = copy.deepcopy(schema["allOf"][0])
+        for x in schema["allOf"][1:]:
+            _dict_merge(schema_, x)
+
+        return _parse_schema(schema_, method)
+
+    # anyOf: Must be valid against any of the subschemas
+    # TODO(stephenfin): Handle anyOf
+
+    # oneOf: Must be valid against exactly one of the subschemas
+    if "oneOf" in schema:
+        # we only show the first one since we can't show everything
+        return _parse_schema(schema["oneOf"][0], method)
+
+    if "enum" in schema:
+        # we only show the first one since we can't show everything
+        return schema["enum"][0]
+
+    schema_type = schema.get("type", "object")
+
+    if schema_type == "array":
+        # special case oneOf and anyOf so that we can show examples for all
+        # possible combinations
+        if "oneOf" in schema["items"]:
+            return [_parse_schema(x, method) for x in schema["items"]["oneOf"]]
+
+        if "anyOf" in schema["items"]:
+            return [_parse_schema(x, method) for x in schema["items"]["anyOf"]]
+
+        return [_parse_schema(schema["items"], method)]
+
+    if schema_type == "object":
+        if (
+            method
+            and "properties" in schema
+            and all(v.get("readOnly", False) for v in schema["properties"].values())
+        ):
+            return _READONLY_PROPERTY
+
+        results = []
+        for name, prop in schema.get("properties", {}).items():
+            result = _parse_schema(prop, method)
+            if result != _READONLY_PROPERTY:
+                results.append((name, result))
+
+        return collections.OrderedDict(results)
+
+    if (schema_type, schema.get("format")) in _TYPE_MAPPING:
+        return _TYPE_MAPPING[(schema_type, schema.get("format"))]
+
+    return _TYPE_MAPPING[(schema_type, None)]  # unrecognized format
+
+
+def _example(media_type_objects, method=None, endpoint=None, status=None, nb_indent=0):
+    """
+    Format examples in `Media Type Object` openapi v3 to HTTP request or
+    HTTP response example.
+    If method and endpoint is provided, this function prints a request example
+    else status should be provided to print a response example.
+
+    Arguments:
+        media_type_objects (Dict[str, Dict]): Dict containing
+            Media Type Objects.
+        method: The HTTP method to use in example.
+        endpoint: The HTTP route to use in example.
+        status: The HTTP status to use in example.
+    """
+    indent = "   "
+    extra_indent = indent * nb_indent
+
+    if method is not None:
+        method = method.upper()
+    else:
+        try:
+            # one of possible values for status might be 'default'.
+            # in the case, just fallback to '-'
+            status_text = http_status_codes[int(status)]
+        except (ValueError, KeyError):
+            status_text = "-"
+
+    # Provide request samples for GET requests
+    if method == "GET":
+        media_type_objects[""] = {"examples": {"Example request": {"value": ""}}}
+
+    for content_type, content in media_type_objects.items():
+        examples = content.get("examples")
+        example = content.get("example")
+
+        # Try to get the example from the schema
+        if example is None and "schema" in content:
+            example = content["schema"].get("example")
+
+        if examples is None:
+            examples = {}
+            if not example:
+                if re.match(r"application/[a-zA-Z\+]*json", content_type) is None:
+                    LOG.info("skipping non-JSON example generation.")
+                    continue
+                example = _parse_schema(content["schema"], method=method)
+
+            if method is None:
+                examples["Example response"] = {
+                    "value": example,
+                }
+            else:
+                examples["Example request"] = {
+                    "value": example,
+                }
+
+        for example in examples.values():
+            # According to OpenAPI v3 specs, string examples should be left unchanged
+            if not isinstance(example["value"], str):
+                example["value"] = json.dumps(
+                    example["value"], indent=4, separators=(",", ": ")
+                )
+
+        for example_name, example in examples.items():
+            if "summary" in example:
+                example_title = "{example_name} - {example[summary]}".format(**locals())
+            else:
+                example_title = example_name
+
+            yield ""
+            yield "{extra_indent}**{example_title}:**".format(**locals())
+            yield ""
+            yield "{extra_indent}.. sourcecode:: http".format(**locals())
+            yield ""
+
+            # Print http request example
+            if method:
+                yield "{extra_indent}{indent}{method} {endpoint} HTTP/1.1".format(
+                    **locals()
+                )
+                yield "{extra_indent}{indent}Host: example.com".format(**locals())
+                if content_type:
+                    yield "{extra_indent}{indent}Content-Type: {content_type}".format(
+                        **locals()
+                    )
+
+            # Print http response example
+            else:
+                yield "{extra_indent}{indent}HTTP/1.1 {status} {status_text}".format(
+                    **locals()
+                )
+                yield "{extra_indent}{indent}Content-Type: {content_type}".format(
+                    **locals()
+                )
+
+            yield ""
+            for example_line in example["value"].splitlines():
+                yield "{extra_indent}{indent}{example_line}".format(**locals())
+            if example["value"].splitlines():
+                yield ""
+
+
+def _httpresource(
+    endpoint, method, properties, convert, render_examples, render_request
+):
+    # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#operation-object
+    parameters = properties.get("parameters", [])
+    responses = properties["responses"]
+    query_param_examples = []
+    indent = "   "
+
+    yield ".. http:{0}:: {1}".format(method, endpoint)
+    yield "   :synopsis: {0}".format(properties.get("summary", "null"))
+    yield ""
+
+    if "summary" in properties:
+        for line in properties["summary"].splitlines():
+            yield "{indent}**{line}**".format(**locals())
+        yield ""
+
+    if "description" in properties:
+        for line in convert(properties.get("description", "")).splitlines():
+            yield "{indent}{line}".format(**locals())
+        yield ""
+
+    # print request's path params
+    for param in filter(lambda p: p["in"] == "path", parameters):
+        yield indent + ":param {type} {name}:".format(
+            type=param["schema"]["type"], name=param["name"]
+        )
+
+        for line in convert(param.get("description", "")).splitlines():
+            yield "{indent}{indent}{line}".format(**locals())
+
+    # print request's query params
+    for param in filter(lambda p: p["in"] == "query", parameters):
+        yield indent + ":query {type} {name}:".format(
+            type=param["schema"]["type"], name=param["name"]
+        )
+        for line in convert(param.get("description", "")).splitlines():
+            yield "{indent}{indent}{line}".format(**locals())
+        if param.get("required", False):
+            yield "{indent}{indent}(Required)".format(**locals())
+            example = _parse_schema(param["schema"], method)
+            example = param.get("example", example)
+            if param.get("explode", False) and isinstance(example, list):
+                for v in example:
+                    query_param_examples.append((param["name"], v))
+            elif param.get("explode", False) and isinstance(example, dict):
+                for k, v in example.items():
+                    query_param_examples.append((k, v))
+            else:
+                query_param_examples.append((param["name"], example))
+
+    # print request content
+    if render_request:
+        request_content = properties.get("requestBody", {}).get("content", {})
+        if request_content and "application/json" in request_content:
+            schema = request_content["application/json"]["schema"]
+            req_properties = json.dumps(
+                schema["properties"], indent=2, separators=(",", ":")
+            )
+            yield "{indent}**Request body:**".format(**locals())
+            yield ""
+            yield "{indent}.. sourcecode:: json".format(**locals())
+            yield ""
+            for line in req_properties.splitlines():
+                # yield indent + line
+                yield "{indent}{indent}{line}".format(**locals())
+                # yield ''
+
+    # print request example
+    if render_examples:
+        endpoint_examples = endpoint
+        if query_param_examples:
+            endpoint_examples = endpoint + "?" + parse.urlencode(query_param_examples)
+
+        # print request example
+        request_content = properties.get("requestBody", {}).get("content", {})
+        for line in _example(
+            request_content, method, endpoint=endpoint_examples, nb_indent=1
+        ):
+            yield line
+
+    # print response status codes
+    for status, response in responses.items():
+        yield "{indent}:status {status}:".format(**locals())
+        for line in convert(response.get("description", "")).splitlines():
+            yield "{indent}{indent}{line}".format(**locals())
+
+        # print response example
+        if render_examples:
+            for line in _example(
+                response.get("content", {}), status=status, nb_indent=2
+            ):
+                yield line
+
+    # print request header params
+    for param in filter(lambda p: p["in"] == "header", parameters):
+        yield indent + ":reqheader {name}:".format(**param)
+        for line in convert(param.get("description", "")).splitlines():
+            yield "{indent}{indent}{line}".format(**locals())
+        if param.get("required", False):
+            yield "{indent}{indent}(Required)".format(**locals())
+
+    # print response headers
+    for status, response in responses.items():
+        for headername, header in response.get("headers", {}).items():
+            yield indent + ":resheader {name}:".format(name=headername)
+            for line in convert(header.get("description", "")).splitlines():
+                yield "{indent}{indent}{line}".format(**locals())
+
+    for cb_name, cb_specs in properties.get("callbacks", {}).items():
+        yield ""
+        yield indent + ".. admonition:: Callback: " + cb_name
+        yield ""
+
+        for cb_endpoint in cb_specs.keys():
+            for cb_method, cb_properties in cb_specs[cb_endpoint].items():
+                for line in _httpresource(
+                    cb_endpoint,
+                    cb_method,
+                    cb_properties,
+                    convert=convert,
+                    render_examples=render_examples,
+                    render_request=render_request,
+                ):
+                    if line:
+                        yield indent + indent + line
+                    else:
+                        yield ""
+
+    yield ""
+
+
+def _header(title):
+    yield title
+    yield "=" * len(title)
+    yield ""
+
+
+def openapihttpdomain(spec, **options):
+    generators = []
+
+    # OpenAPI spec may contain JSON references, common properties, etc.
+    # Trying to render the spec "As Is" will require to put multiple
+    # if-s around the code. In order to simplify flow, let's make the
+    # spec to have only one (expected) schema, i.e. normalize it.
+    utils.normalize_spec(spec, **options)
+
+    # Paths list to be processed
+    paths = []
+
+    # If 'paths' are passed we've got to ensure they exist within an OpenAPI
+    # spec; otherwise raise error and ask user to fix that.
+    if "paths" in options:
+        if not set(options["paths"]).issubset(spec["paths"]):
+            raise ValueError(
+                "One or more paths are not defined in the spec: %s."
+                % (", ".join(set(options["paths"]) - set(spec["paths"])),)
+            )
+        paths = options["paths"]
+
+    # Check against regular expressions to be included
+    if "include" in options:
+        for i in options["include"]:
+            ir = re.compile(i)
+            for path in spec["paths"]:
+                if ir.match(path):
+                    paths.append(path)
+
+    # If no include nor paths option, then take full path
+    if "include" not in options and "paths" not in options:
+        paths = spec["paths"]
+
+    # Remove paths matching regexp
+    if "exclude" in options:
+        _paths = []
+        for e in options["exclude"]:
+            er = re.compile(e)
+            for path in paths:
+                if not er.match(path):
+                    _paths.append(path)
+        paths = _paths
+
+    render_request = False
+    if "request" in options:
+        render_request = True
+
+    convert = utils.get_text_converter(options)
+
+    # https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.0.md#paths-object
+    if "group" in options:
+        groups = collections.OrderedDict(
+            [(x["name"], []) for x in spec.get("tags", {})]
+        )
+
+        for endpoint in paths:
+            for method, properties in spec["paths"][endpoint].items():
+                key = properties.get("tags", [""])[0]
+                groups.setdefault(key, []).append(
+                    _httpresource(
+                        endpoint,
+                        method,
+                        properties,
+                        convert,
+                        render_examples="examples" in options,
+                        render_request=render_request,
+                    )
+                )
+
+        for key in groups.keys():
+            if key:
+                generators.append(_header(key))
+            else:
+                generators.append(_header("default"))
+
+            generators.extend(groups[key])
+    else:
+        for endpoint in paths:
+            for method, properties in spec["paths"][endpoint].items():
+                generators.append(
+                    _httpresource(
+                        endpoint,
+                        method,
+                        properties,
+                        convert,
+                        render_examples="examples" in options,
+                        render_request=render_request,
+                    )
+                )
+
+    return iter(itertools.chain(*generators))

--- a/sphinxcontrib/openapi/renderers/_httpdomain_old.py
+++ b/sphinxcontrib/openapi/renderers/_httpdomain_old.py
@@ -3,7 +3,7 @@
 from docutils.parsers.rst import directives
 
 from . import abc
-from .. import openapi20, openapi30, utils
+from .. import openapi20, openapi30, openapi31, utils
 
 
 class HttpdomainOldRenderer(abc.RestructuredTextRenderer):
@@ -41,13 +41,15 @@ class HttpdomainOldRenderer(abc.RestructuredTextRenderer):
         # have only one (expected) schema, i.e. normalize it.
         utils.normalize_spec(spec, **self._options)
 
-        # We support both OpenAPI 2.0 (f.k.a. Swagger) and OpenAPI 3.0.0, so
-        # determine which version we are parsing here.
+        # We support OpenAPI 2.0 (f.k.a. Swagger), OpenAPI 3.0 and OpenAPI 3.1,
+        # so determine which version we are parsing here.
         spec_version = spec.get("openapi", spec.get("swagger", "2.0"))
         if spec_version.startswith("2."):
             openapihttpdomain = openapi20.openapihttpdomain
-        elif spec_version.startswith("3."):
+        elif spec_version.startswith("3.0."):
             openapihttpdomain = openapi30.openapihttpdomain
+        elif spec_version.startswith("3.1."):
+            openapihttpdomain = openapi31.openapihttpdomain
         else:
             raise ValueError("Unsupported OpenAPI version (%s)" % spec_version)
 

--- a/sphinxcontrib/openapi/utils.py
+++ b/sphinxcontrib/openapi/utils.py
@@ -99,7 +99,7 @@ def normalize_spec(spec, **options):
     # In order to do not place if-s around the code to handle special
     # cases, let's normalize the spec and push common parameters inside
     # endpoints definitions.
-    for endpoint in spec['paths'].values():
+    for endpoint in spec.get('paths', {}).values():
         parameters = endpoint.pop('parameters', [])
         for method in endpoint.values():
             method.setdefault('parameters', [])

--- a/tests/test_spec_examples.py
+++ b/tests/test_spec_examples.py
@@ -43,11 +43,30 @@ def test_openapi2_success(tmpdir, run_sphinx, spec):
         'v3.0',
         '*.yaml')
 ))
-def test_openapi3_success(tmpdir, run_sphinx, spec, render_examples,
-                          render_request, group_paths):
+def test_openapi30_success(tmpdir, run_sphinx, spec, render_examples,
+                           render_request, group_paths):
     py.path.local(spec).copy(tmpdir.join('src', 'test-spec.yml'))
     run_sphinx('test-spec.yml', options={
         'examples': render_examples,
         'request': render_request,
         'group': group_paths,
+    })
+
+
+@pytest.mark.parametrize('render_examples', [False, True])
+@pytest.mark.parametrize('render_request', [False, True])
+@pytest.mark.parametrize('spec', glob.glob(
+    os.path.join(
+        os.path.abspath(os.path.dirname(__file__)),
+        'OpenAPI-Specification',
+        'examples',
+        'v3.1',
+        '*.yaml')
+))
+def test_openapi31_success(tmpdir, run_sphinx, spec, render_examples,
+                           render_request):
+    py.path.local(spec).copy(tmpdir.join('src', 'test-spec.yml'))
+    run_sphinx('test-spec.yml', options={
+        'examples': render_examples,
+        'request': render_request,
     })

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest
     responses
 commands =
-    {envpython} -m pytest tests/ --strict-markers {posargs}
+    {envpython} -m pytest --strict-markers {posargs:tests/}
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
This isn't my finest work but it passes with the schema I'm using locally.
There are quite a few changes in OpenAPI 3.1 but two are addressed here:

- 'nullable' is gone in favour of the 'null' type and type arrays
- 'paths' is now optional and spec files can contain only components

There's a whole lot more to support here including things like webhooks but we
focus on the MVP here. All that extra functionality can be added later.

A list of commits:

- `Add initial framework for OpenAPI 3.1`
- `OAS 3.1: Support specs without 'paths'`
- `OAS 3.1: Support null type`
- `OAS 3.1: Prefer non-null values`
- `tox: Allow running specific tests`
- `Update OpenAPI-Specification submodule`
- `Add tests for OpenAPI 3.1 schemas`
