### PR TITLE
fix: [openapi31] Fixes #146 when anyOf is used in schemas.

### DIFF
--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -302,7 +302,7 @@ def _httpresource(
             dtype = schema["type"]
         else:
             dtype = set()
-            for t in schema["anyOf"]:
+            for t in schema.get("anyOf", []):
                 if "format" in t.keys():
                     dtype.add(t["format"])
                 else:


### PR DESCRIPTION
Change to address the issue #146. Description of the problem is in the issue.

Tested on my side.

Let me know if you will merge it. I need to deploy a documentation with sphinx-contrib-openapi on ReadTheDocs.org.

Thank you very much.

