### PR TITLE
support allOf in parameters schema

### DIFF
--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -302,7 +302,7 @@ def _httpresource(
             dtype = schema["type"]
         else:
             dtype = set()
-            for t in schema["anyOf"]:
+            for t in schema.get("anyOf", schema.get("allOf")):
                 if "format" in t.keys():
                     dtype.add(t["format"])
                 else:

--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -302,7 +302,7 @@ def _httpresource(
             dtype = schema["type"]
         else:
             dtype = set()
-            for t in schema.get("anyOf", schema.get("allOf")):
+            for t in schema.get("anyOf", schema.get("allOf", [])):
                 if "format" in t.keys():
                     dtype.add(t["format"])
                 else:


### PR DESCRIPTION
I use FastAPI to generate openapi spec. It produces `allOf` schemas for enums in parameters which is valid according to OpenAPI specification.

This PR fixes issue for me and removes warning (actually exception).

make html output without this fix:

```
Traceback (most recent call last):
  File "~/.venv/lib/python3.10/site-packages/sphinx/cmd/build.py", line 337, in build_main
    app.build(args.force_all, args.filenames)
  File "~/.venv/lib/python3.10/site-packages/sphinx/application.py", line 378, in build
    self.builder.build_update()
  File "~/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 297, in build_update
    self.build(to_build,
  File "~/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 318, in build
    updated_docnames = set(self.read())
  File "~/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 425, in read
    self._read_serial(docnames)
  File "~/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 477, in _read_serial
    self.read_doc(docname)
  File "~/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 536, in read_doc
    publisher.publish()
  File "~/.venv/lib/python3.10/site-packages/docutils/core.py", line 234, in publish
    self.document = self.reader.read(self.source, self.parser,
  File "~/.venv/lib/python3.10/site-packages/sphinx/io.py", line 106, in read
    self.parse()
  File "~/.venv/lib/python3.10/site-packages/docutils/readers/__init__.py", line 76, in parse
    self.parser.parse(self.input, document)
  File "~/.venv/lib/python3.10/site-packages/sphinx/parsers.py", line 83, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 169, in run
    results = StateMachineWS.run(self, input_lines, input_offset,
  File "~/.venv/lib/python3.10/site-packages/docutils/statemachine.py", line 233, in run
    context, next_state, result = self.check_line(
  File "~/.venv/lib/python3.10/site-packages/docutils/statemachine.py", line 445, in check_line
    return method(match, context, next_state)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2790, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 325, in section
    self.new_subsection(title, lineno, messages)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 391, in new_subsection
    newabsoffset = self.nested_parse(
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 279, in nested_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 195, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "~/.venv/lib/python3.10/site-packages/docutils/statemachine.py", line 233, in run
    context, next_state, result = self.check_line(
  File "~/.venv/lib/python3.10/site-packages/docutils/statemachine.py", line 445, in check_line
    return method(match, context, next_state)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2357, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2369, in explicit_construct
    return method(self, expmatch)
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2106, in directive
    return self.run_directive(
  File "~/.venv/lib/python3.10/site-packages/docutils/parsers/rst/states.py", line 2156, in run_directive
    result = directive_instance.run()
  File "~/.venv/lib/python3.10/site-packages/sphinxcontrib/openapi/directive.py", line 56, in run
    return renderer_cls(self.state, self.options).render(spec)
  File "~/.venv/lib/python3.10/site-packages/sphinxcontrib/openapi/renderers/abc.py", line 40, in render
    for line in self.render_restructuredtext_markup(spec):
  File "~/.venv/lib/python3.10/site-packages/sphinxcontrib/openapi/renderers/_httpdomain_old.py", line 55, in render_restructuredtext_markup
    yield from openapihttpdomain(spec, **self._options)
  File "~/.venv/lib/python3.10/site-packages/sphinxcontrib/openapi/openapi31.py", line 322, in _httpresource
    type_ = _get_type_from_schema(param["schema"])
  File "~/.venv/lib/python3.10/site-packages/sphinxcontrib/openapi/openapi31.py", line 305, in _get_type_from_schema
    for t in schema["anyOf"]:
KeyError: 'anyOf'

Exception occurred:
  File "~/.venv/lib/python3.10/site-packages/sphinxcontrib/openapi/openapi31.py", line 305, in _get_type_from_schema
    for t in schema["anyOf"]:
KeyError: 'anyOf'
```

Schema example:

```
---
openapi: "3.1.0"
info:
  title: "Reproducer for issue #163"
  version: 2.0.0
paths:
  /users:
    get:
      summary: Get all users.
      parameters:
        - in: query
          name: role
          schema:
            # This is how FastAPI renders Enum in parameters
            allOf:
              - type: "string"
                enum: ["admin", "member", "reader"]
                title: Example Enum param
            default: "admin"
      responses:
        "200":
          description: A list of all users.
          content:
            application/json:
              schema:
                type: object
                properties:
                  success:
                    type: bool
```