### PR TITLE
Support OpenAPI Specification 3.1.1

### DIFF
--- a/sphinxcontrib/openapi/openapi31.py
+++ b/sphinxcontrib/openapi/openapi31.py
@@ -279,7 +279,7 @@ def _httpresource(
 ):
     # https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#operation-object
     parameters = properties.get("parameters", [])
-    responses = properties["responses"]
+    responses = properties.get("responses", {})
     query_param_examples = []
     indent = "   "
 


### PR DESCRIPTION
OAS 3.1.1 added
https://github.com/OAI/OpenAPI-Specification/blob/main/tests/v3.1/pass/non-oauth-scopes.yaml, which indicates that it's possible for the `responses` object to be missing; this caused a test failure.  It seems reasonable enough to default to an empty dictionary.